### PR TITLE
Make the metadata mandatory for send transactions

### DIFF
--- a/cfdp-core/src/daemon.rs
+++ b/cfdp-core/src/daemon.rs
@@ -746,8 +746,9 @@ impl<T: FileStore + Send + Sync + 'static> Daemon<T> {
                     false => FileSizeFlag::Large,
                 };
 
-                let mut transaction = SendTransaction::new(config, filestore, transport_tx);
-                transaction.put(metadata)?;
+                let mut transaction =
+                    SendTransaction::new(config, metadata, filestore, transport_tx);
+                transaction.start()?;
 
                 while transaction.get_state() != &TransactionState::Terminated {
                     // this function handles any timeouts and resends


### PR DESCRIPTION
Since the send transactions have been split from the receive transactions, the metadata can now be made mandatory for the send to reduce the clutter. Fixes #10