### PR TITLE
User trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,6 @@ dependencies = [
  "byteorder",
  "camino",
  "crossbeam-channel",
- "dirs",
  "interprocess",
  "itertools",
  "log",
@@ -155,26 +154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -306,17 +285,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -527,17 +495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,12 +702,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 # cfdp-rs
 This project aims to be a feature-complete, cross-platform, open source Rust implementation of the CCSDS File Delivery Protocol (CFDP).
 
-Currently issues with communcation pipes prevents thorough testing on MacOs and Windows platforms.
-Development is needed on these platforms to validate functionality and improve stability.
+The User interface is left as an application specific implementation with attaches to the underlying Daemon through the `User` trait interface.
 
 # Optional Features
 The following optional features are currently or planned to be impelemented
@@ -15,7 +14,10 @@ The following optional features are currently or planned to be impelemented
 - [ ] Data boundary segmentation
 - [x] Delayed NAK mode
 - [x] Immediate NAK mode
+- [ ] Prompted NAK mode
 - [ ] Asynchronous NAK mode
+
+The Prompt NAK mode is technically implemented for an Acknowledged transaction via the Prompt PDU however currently a RecvTransaction will attempt to send NAKs at other times depending on the configuration.
 
 # Inter-Agency Tests
 This software suite currently implements the following Common Inter-Agency Tests:

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The following optional features are currently or planned to be impelemented
 - [ ] Data boundary segmentation
 - [x] Delayed NAK mode
 - [x] Immediate NAK mode
-- [ ] Prompted NAK mode
+- [x] Prompted NAK mode
 - [ ] Asynchronous NAK mode
 
-The Prompt NAK mode is technically implemented for an Acknowledged transaction via the Prompt PDU however currently a RecvTransaction will attempt to send NAKs at other times depending on the configuration.
+
 
 # Inter-Agency Tests
 This software suite currently implements the following Common Inter-Agency Tests:

--- a/cfdp-core/Cargo.toml
+++ b/cfdp-core/Cargo.toml
@@ -23,6 +23,5 @@ tempfile = "~3.3"
 thiserror = "~1.0"
 
 [dev-dependencies]
-dirs = "~4.0"
 rstest = "0.15.0"
 signal-hook = "~0.3"

--- a/cfdp-core/Cargo.toml
+++ b/cfdp-core/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2021"
 
 [features]
 uart = ["serialport"]
+ipc = ["interprocess"]
 
 
 [dependencies]
 byteorder = "~1.4"
 camino = {version = "~1.1", features=["serde1"]}
 crossbeam-channel = "~0.5"
-interprocess = "~1.2"
+interprocess = { version = "~1.2", optional = true}
 itertools = "~0.10"
 log = '~0.4'
 num-derive = "0.3"

--- a/cfdp-core/Cargo.toml
+++ b/cfdp-core/Cargo.toml
@@ -19,10 +19,10 @@ num-derive = "0.3"
 num-traits = "0.2"
 pathdiff = "~0.2"
 serialport = { version = "~4.2", optional = true }
-signal-hook = "~0.3"
 tempfile = "~3.3"
 thiserror = "~1.0"
 
 [dev-dependencies]
-rstest = "0.15.0"
 dirs = "~4.0"
+rstest = "0.15.0"
+signal-hook = "~0.3"

--- a/cfdp-core/src/daemon.rs
+++ b/cfdp-core/src/daemon.rs
@@ -284,6 +284,7 @@ enum Command {
 
 /// Simple Status Report
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Report {
     pub id: TransactionID,
     pub state: TransactionState,

--- a/cfdp-core/src/transaction/send.rs
+++ b/cfdp-core/src/transaction/send.rs
@@ -1061,8 +1061,8 @@ mod test {
                     closure_requested: false,
                     file_size: 10,
                     checksum_type: ChecksumType::Modular,
-                    source_filename: path.clone().as_str().as_bytes().to_vec(),
-                    destination_filename: path.clone().as_str().as_bytes().to_vec(),
+                    source_filename: path.as_str().as_bytes().to_vec(),
+                    destination_filename: path.as_str().as_bytes().to_vec(),
                     options: vec![],
                 }));
                 let payload_len = payload

--- a/cfdp-core/src/transport.rs
+++ b/cfdp-core/src/transport.rs
@@ -42,8 +42,8 @@ pub trait PDUTransport {
     /// A transport implementation will send any received messages through the
     /// [Sender] channel to the [Daemon](crate::daemon::Daemon).
     /// The [Receiver] channel is used to recv PDUs from the Daemon and send them to their respective remote Entity.
-    /// The [Daemon](crate::daemon::Daemon) is responsible for receiving messages and ditribute them to each
-    /// [Transaction](crate::transaction::Transaction) as necessary.
+    /// The [Daemon](crate::daemon::Daemon) is responsible for receiving messages and distribute them to each
+    /// transaction [Send](crate::transaction::SendTransaction) or [Recv](crate::transaction::RecvTransaction)
     /// The signal is used to indicate a shutdown operation was requested.
     fn pdu_handler(
         &mut self,

--- a/cfdp-core/src/user.rs
+++ b/cfdp-core/src/user.rs
@@ -44,6 +44,12 @@ pub use ipc::IpcUser;
 
 #[cfg(feature = "ipc")]
 mod ipc {
+
+    #[cfg(windows)]
+    pub(crate) const SOCKET_ADDR: &str = "cfdp";
+    #[cfg(not(windows))]
+    pub const SOCKET_ADDR: &str = "/var/run/cfdp.socket";
+
     use camino::Utf8PathBuf;
     use crossbeam_channel::{bounded, Sender};
     use interprocess::local_socket::{LocalSocketListener, LocalSocketStream};
@@ -75,9 +81,11 @@ mod ipc {
     impl IpcUser {
         /// Create a new IpcUser instance at the provided socket address.
         /// The address must be compatible with [Utf8PathBuf] .
-        pub fn new(socket: &(impl AsRef<str> + ?Sized)) -> Result<Self, IoError> {
+        pub fn new(socket: Option<&(impl AsRef<str> + ?Sized)>) -> Result<Self, IoError> {
             Ok(Self {
-                socket: Utf8PathBuf::from(socket),
+                socket: socket
+                    .map(Utf8PathBuf::from)
+                    .unwrap_or_else(|| Utf8PathBuf::from(SOCKET_ADDR)),
             })
         }
 

--- a/cfdp-core/src/user.rs
+++ b/cfdp-core/src/user.rs
@@ -1,88 +1,268 @@
-use std::io::{Error as IoError, ErrorKind, Read, Write};
+use std::{
+    io::Error as IoError,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 use crate::{
-    daemon::{PutRequest, Report, UserPrimitive, SOCKET_ADDR},
-    pdu::{EntityID, PDUEncode, TransactionSeqNum},
+    daemon::{Report, UserPrimitive},
     transaction::TransactionID,
 };
 
-use camino::Utf8PathBuf;
-use interprocess::local_socket::LocalSocketStream;
+use crossbeam_channel::Sender;
 
-pub struct User {
-    socket: Utf8PathBuf,
+#[derive(Debug)]
+/// Some User interactions require the ID to be returned to the user
+/// or the status report requested.
+// this enum allows us to send a one-off channel to the Daemon
+// then listen for the response.
+pub enum UserReturn {
+    ID(TransactionID),
+    Report(Option<Report>),
 }
-impl User {
-    pub fn new(socket_address: Option<&str>) -> Result<Self, IoError> {
-        let socket = socket_address.unwrap_or(SOCKET_ADDR);
-        Ok(Self {
-            socket: Utf8PathBuf::from(socket),
-        })
+
+/// The CFDP user is an interface to initiate transactions
+/// and receive status updates for users. It interfaces with the [Daemon](crate::daemon::Daemon)
+/// through a channel to relay any input [UserPrimitive](crate::daemon::UserPrimitive) and recieve any requested [Report](crate::daemon::Report).
+pub trait User {
+    /// Provides any logic for communicating UserPrimitives to the [Daemon](crate::daemon::Daemon).
+
+    /// A User implementation will listen for any incoming [UserPrimitive](crate::daemon::UserPrimitive)
+    /// from its user-facing counterpart (implementation specific)
+    /// forward it over the sender channel to the [Daemon](crate::daemon::Daemon).
+    /// Any requested [Report](crate::daemon::Report) is returned on the receiving channel.
+    /// The signal is used to indicate a shutdown operation was requested.
+    fn primitive_handler(
+        &mut self,
+        signal: Arc<AtomicBool>,
+        sender: Sender<(UserPrimitive, Sender<UserReturn>)>,
+        // recv: Receiver<Report>,
+    ) -> Result<(), IoError>;
+}
+
+#[cfg(feature = "ipc")]
+pub use ipc::IpcUser;
+
+#[cfg(feature = "ipc")]
+mod ipc {
+    use camino::Utf8PathBuf;
+    use crossbeam_channel::{bounded, Sender};
+    use interprocess::local_socket::{LocalSocketListener, LocalSocketStream};
+    use log::error;
+    use std::{
+        fs,
+        io::{Error as IoError, ErrorKind, Read, Write},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread,
+        time::Duration,
+    };
+
+    use crate::{
+        daemon::{PutRequest, Report, UserPrimitive},
+        pdu::{EntityID, PDUEncode, TransactionSeqNum},
+        transaction::TransactionID,
+    };
+
+    use super::{User, UserReturn};
+
+    /// A default implementation of the [User] trait which uses [LocalSocketListener]
+    /// to communicate between a user facing command line process and the internal User implemenation.
+    pub struct IpcUser {
+        socket: Utf8PathBuf,
     }
-    fn send(&mut self, primitive: UserPrimitive) -> Result<(), IoError> {
-        let mut connection = LocalSocketStream::connect(self.socket.as_str())?;
-        connection.write_all(primitive.encode().as_slice())
-    }
-
-    pub fn put(&mut self, request: PutRequest) -> Result<TransactionID, IoError> {
-        let primitive = UserPrimitive::Put(request);
-        let id = {
-            let mut connection = LocalSocketStream::connect(self.socket.as_str())?;
-            connection.write_all(primitive.encode().as_slice())?;
-
-            (
-                EntityID::decode(&mut connection)
-                    .map_err(|_| IoError::from(ErrorKind::InvalidData))?,
-                TransactionSeqNum::decode(&mut connection)
-                    .map_err(|_| IoError::from(ErrorKind::InvalidData))?,
-            )
-        };
-        Ok(id)
-    }
-
-    pub fn suspend(&mut self, transaction: TransactionID) -> Result<(), IoError> {
-        self.send(UserPrimitive::Suspend(transaction.0, transaction.1))
-    }
-
-    pub fn resume(&mut self, transaction: TransactionID) -> Result<(), IoError> {
-        self.send(UserPrimitive::Resume(transaction.0, transaction.1))
-    }
-
-    pub fn cancel(&mut self, transaction: TransactionID) -> Result<(), IoError> {
-        self.send(UserPrimitive::Cancel(transaction.0, transaction.1))
-    }
-    pub fn report(&mut self, transaction: TransactionID) -> Result<Option<Report>, IoError> {
-        let primitive = UserPrimitive::Report(transaction.0, transaction.1);
-
-        let report = {
-            let mut connection = LocalSocketStream::connect(self.socket.as_str())?;
-
-            connection.write_all(primitive.encode().as_slice())?;
-
-            {
-                let mut u64_buff = [0_u8; 8];
-                connection.read_exact(&mut u64_buff)?;
-
-                match u64::from_be_bytes(u64_buff) {
-                    0 => None,
-                    _ => Some(
-                        Report::decode(&mut connection)
-                            .map_err(|_| IoError::from(ErrorKind::InvalidData))?,
-                    ),
-                }
-            }
-        };
-        match &report {
-            Some(data) => println!(
-                "Status of Transaction ({:?}, {:?}). State: {:?}. Status: {:?}. Condition: {:?}.",
-                data.id.0, data.id.1, data.state, data.status, data.condition
-            ),
-            None => println!(
-                "No Report available for ({:?} , {:?})",
-                transaction.0, transaction.1
-            ),
+    impl IpcUser {
+        /// Create a new IpcUser instance at the provided socket address.
+        /// The address must be compatible with [Utf8PathBuf] .
+        pub fn new(socket: &(impl AsRef<str> + ?Sized)) -> Result<Self, IoError> {
+            Ok(Self {
+                socket: Utf8PathBuf::from(socket),
+            })
         }
 
-        Ok(report)
+        fn send(&mut self, primitive: UserPrimitive) -> Result<(), IoError> {
+            let mut connection = LocalSocketStream::connect(self.socket.as_str())?;
+            connection.write_all(primitive.encode().as_slice())
+        }
+
+        /// Send the input [PutRequest] to the daemon to initiate a CFDP transfer
+        pub fn put(&mut self, request: PutRequest) -> Result<TransactionID, IoError> {
+            let primitive = UserPrimitive::Put(request);
+            let id = {
+                let mut connection = LocalSocketStream::connect(self.socket.as_str())?;
+                connection.write_all(primitive.encode().as_slice())?;
+
+                (
+                    EntityID::decode(&mut connection)
+                        .map_err(|_| IoError::from(ErrorKind::InvalidData))?,
+                    TransactionSeqNum::decode(&mut connection)
+                        .map_err(|_| IoError::from(ErrorKind::InvalidData))?,
+                )
+            };
+            Ok(id)
+        }
+
+        /// Suspend the input transactin
+        pub fn suspend(&mut self, transaction: TransactionID) -> Result<(), IoError> {
+            self.send(UserPrimitive::Suspend(transaction.0, transaction.1))
+        }
+
+        /// Resume the input transaction
+        pub fn resume(&mut self, transaction: TransactionID) -> Result<(), IoError> {
+            self.send(UserPrimitive::Resume(transaction.0, transaction.1))
+        }
+
+        /// Cancel the input transaction
+        pub fn cancel(&mut self, transaction: TransactionID) -> Result<(), IoError> {
+            self.send(UserPrimitive::Cancel(transaction.0, transaction.1))
+        }
+
+        /// Receive the latest [Report] for the given transaction.
+        pub fn report(&mut self, transaction: TransactionID) -> Result<Option<Report>, IoError> {
+            let primitive = UserPrimitive::Report(transaction.0, transaction.1);
+
+            let report = {
+                let mut connection = LocalSocketStream::connect(self.socket.as_str())?;
+
+                connection.write_all(primitive.encode().as_slice())?;
+
+                {
+                    let mut u64_buff = [0_u8; 8];
+                    connection.read_exact(&mut u64_buff)?;
+
+                    match u64::from_be_bytes(u64_buff) {
+                        0 => None,
+                        _ => Some(
+                            Report::decode(&mut connection)
+                                .map_err(|_| IoError::from(ErrorKind::InvalidData))?,
+                        ),
+                    }
+                }
+            };
+            match &report {
+                Some(data) => println!(
+                    "Status of Transaction ({:?}, {:?}). State: {:?}. Status: {:?}. Condition: {:?}.",
+                    data.id.0, data.id.1, data.state, data.status, data.condition
+                ),
+                None => println!(
+                    "No Report available for ({:?} , {:?})",
+                    transaction.0, transaction.1
+                ),
+            }
+
+            Ok(report)
+        }
+    }
+    impl User for IpcUser {
+        fn primitive_handler(
+            &mut self,
+            signal: Arc<AtomicBool>,
+            sender: Sender<(UserPrimitive, Sender<UserReturn>)>,
+        ) -> Result<(), IoError> {
+            if self.socket.exists() {
+                fs::remove_file(self.socket.as_path())?;
+            }
+
+            let listener = LocalSocketListener::bind(self.socket.as_std_path())?;
+            // setting to non-blocking lets us grab conections that are open
+            // without blocking the entire thread.
+            listener.set_nonblocking(true)?;
+            while !signal.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok(mut conn) => {
+                        let (internal_send, internal_recv) = bounded(0);
+                        let primitive = UserPrimitive::decode(&mut conn).map_err(|_| {
+                            IoError::new(
+                                ErrorKind::InvalidData,
+                                "Unable to parse user primitive from connected socket.",
+                            )
+                        })?;
+                        match primitive {
+                            UserPrimitive::Put(_) => {
+                                sender.send((primitive, internal_send)).map_err(|_| {
+                                    IoError::new(
+                                        ErrorKind::ConnectionReset,
+                                        "Daemon Half of User disconnected.",
+                                    )
+                                })?;
+                                let response = internal_recv.recv().map_err(|_| {
+                                    IoError::new(
+                                        ErrorKind::ConnectionReset,
+                                        "Daemon Half of User disconnected.",
+                                    )
+                                })?;
+                                if let UserReturn::ID(id) = response {
+                                    conn.write_all(
+                                        [id.0.encode(), id.1.encode()].concat().as_slice(),
+                                    )?;
+                                }
+                            }
+                            UserPrimitive::Cancel(_, _) => {
+                                sender.send((primitive, internal_send)).map_err(|_| {
+                                    IoError::new(
+                                        ErrorKind::ConnectionReset,
+                                        "Daemon Half of User disconnected.",
+                                    )
+                                })?
+                            }
+                            UserPrimitive::Suspend(_, _) => {
+                                sender.send((primitive, internal_send)).map_err(|_| {
+                                    IoError::new(
+                                        ErrorKind::ConnectionReset,
+                                        "Daemon Half of User disconnected.",
+                                    )
+                                })?
+                            }
+                            UserPrimitive::Resume(_, _) => {
+                                sender.send((primitive, internal_send)).map_err(|_| {
+                                    IoError::new(
+                                        ErrorKind::ConnectionReset,
+                                        "Daemon Half of User disconnected.",
+                                    )
+                                })?
+                            }
+                            UserPrimitive::Report(_, _) => {
+                                sender.send((primitive, internal_send)).map_err(|_| {
+                                    IoError::new(
+                                        ErrorKind::ConnectionReset,
+                                        "Daemon Half of User disconnected.",
+                                    )
+                                })?;
+                                let response = internal_recv.recv().map_err(|_| {
+                                    IoError::new(
+                                        ErrorKind::ConnectionReset,
+                                        "Daemon Half of User disconnected.",
+                                    )
+                                })?;
+                                let vec = match response {
+                                    UserReturn::Report(report) => match report {
+                                        Some(inner) => inner.encode(),
+                                        None => vec![],
+                                    },
+                                    _ => unreachable!(),
+                                };
+                                conn.write_all(
+                                    [(vec.len() as u64).to_be_bytes().to_vec(), vec]
+                                        .concat()
+                                        .as_slice(),
+                                )?;
+                            }
+                        };
+                    }
+                    Err(_err)
+                        if _err.kind() == ErrorKind::WouldBlock
+                            || _err.kind() == ErrorKind::TimedOut =>
+                    {
+                        thread::sleep(Duration::from_millis(100))
+                    }
+                    Err(e) => {
+                        error!("encountered IO error: {e}");
+                        return Err(e);
+                    }
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/cfdp-core/tests/common/mod.rs
+++ b/cfdp-core/tests/common/mod.rs
@@ -97,6 +97,9 @@ impl TestUserHalf {
         }
     }
 
+    // this function is actually used in series_f1 but series_f2 and f3 generate an unused warning
+    // apparently related https://github.com/rust-lang/rust/issues/46379
+    #[allow(unused)]
     pub fn cancel(&self, transaction: TransactionID) -> Result<(), IoError> {
         let primitive = UserPrimitive::Cancel(transaction.0, transaction.1);
         let (send, _recv) = bounded(0);

--- a/cfdp-core/tests/series_f1.rs
+++ b/cfdp-core/tests/series_f1.rs
@@ -26,7 +26,6 @@ use common::{
 };
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(2))]
 // Series F1
 // Sequence 1 Test
@@ -59,7 +58,6 @@ fn f1s1(get_filestore: &UsersAndFilestore) {
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(2))]
 // Series F1
 // Sequence 2 Test
@@ -92,7 +90,6 @@ fn f1s2(get_filestore: &UsersAndFilestore) {
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(10))]
 // Series F1
 // Sequence 3 Test
@@ -174,7 +171,6 @@ fn fixture_f1s4(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(30))]
 // Series F1
 // Sequence 4 Test
@@ -256,7 +252,6 @@ fn fixture_f1s5(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(30))]
 // Series F1
 // Sequence 5 Test
@@ -339,7 +334,6 @@ fn fixture_f1s6(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F1
 // Sequence 6 Test
@@ -375,7 +369,6 @@ fn f1s6(fixture_f1s6: &'static EntityConstructorReturn) {
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(10))]
 // Series F1
 // Sequence 7 Test
@@ -465,7 +458,6 @@ fn f1s7(get_filestore: &UsersAndFilestore) {
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(10))]
 // Series F1
 // Sequence 7 Test
@@ -515,7 +507,6 @@ fn f1s8(get_filestore: &UsersAndFilestore) {
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(30))]
 // Series F1
 // Sequence 7 Test
@@ -569,7 +560,6 @@ fn f1s9(get_filestore: &UsersAndFilestore) {
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(10))]
 // Series F1
 // Sequence 7 Test

--- a/cfdp-core/tests/series_f2.rs
+++ b/cfdp-core/tests/series_f2.rs
@@ -74,7 +74,6 @@ fn fixture_f2s1(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F2
 // Sequence 1 Test
@@ -162,7 +161,6 @@ fn fixture_f2s2(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F2
 // Sequence 2 Test
@@ -248,7 +246,6 @@ fn fixture_f2s3(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F2
 // Sequence 3 Test
@@ -334,7 +331,6 @@ fn fixture_f2s4(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F2
 // Sequence 3 Test
@@ -420,7 +416,6 @@ fn fixture_f2s5(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F2
 // Sequence 5 Test
@@ -504,7 +499,6 @@ fn fixture_f2s6(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(10))]
 // Series F2
 // Sequence 6 Test
@@ -590,7 +584,6 @@ fn fixture_f2s7(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(10))]
 // Series F2
 // Sequence 7 Test
@@ -695,7 +688,6 @@ fn fixture_f2s8(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F2
 // Sequence 8 Test
@@ -793,7 +785,6 @@ fn fixture_f2s9(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F2
 // Sequence 9 Test
@@ -889,10 +880,9 @@ fn fixture_f2s10(
 }
 
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 // Series F2
-// Sequence 9 Test
+// Sequence 10 Test
 // Test goal:
 //  - check Inactivity at Receiver
 // Configuration:

--- a/cfdp-core/tests/series_f3.rs
+++ b/cfdp-core/tests/series_f3.rs
@@ -24,7 +24,6 @@ use common::{get_filestore, UsersAndFilestore};
 //  - File Size: Medium
 //  - Execute remote put from remote. File should exist on remote
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(10))]
 fn f3s01(get_filestore: &UsersAndFilestore) {
     let (_local_user, remote_user, filestore) = get_filestore;
@@ -68,7 +67,6 @@ fn f3s01(get_filestore: &UsersAndFilestore) {
 //  - Acknowledged
 //  - Create New file on remote
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s02(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
@@ -105,7 +103,6 @@ fn f3s02(get_filestore: &UsersAndFilestore) {
 //  - Acknowledged
 //  - Create New file on remote, then delete it with another transaction
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s03(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
@@ -178,7 +175,6 @@ fn f3s03(get_filestore: &UsersAndFilestore) {
 //  - Acknowledged
 //  - Create New file on remote, then Rename it in another transaction
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s04(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
@@ -258,7 +254,6 @@ fn f3s04(get_filestore: &UsersAndFilestore) {
 //  - Transfer M file
 //  - Append new file to first file
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s05(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
@@ -353,7 +348,6 @@ fn f3s05(get_filestore: &UsersAndFilestore) {
 //  - Transfer M file
 //  - Replace small file with medium file
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s06(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
@@ -439,7 +433,6 @@ fn f3s06(get_filestore: &UsersAndFilestore) {
 //  - Acknowledged
 //  - Create new directory
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s07(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
@@ -479,7 +472,6 @@ fn f3s07(get_filestore: &UsersAndFilestore) {
 //  - Create new directory
 //  - Then remove it
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s08(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
@@ -540,7 +532,6 @@ fn f3s08(get_filestore: &UsersAndFilestore) {
 //  - Send M file
 //  - Then DenyFile and verify it is removed
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s09(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
@@ -589,7 +580,7 @@ fn f3s09(get_filestore: &UsersAndFilestore) {
 }
 
 // Series F3
-// Sequence 9 Test
+// Sequence 10 Test
 // Test goal:
 //  - Check DirectoryListing directive
 // Configuration:
@@ -597,7 +588,6 @@ fn f3s09(get_filestore: &UsersAndFilestore) {
 //  - Send Directory listing request
 //  - verify the listing file is created
 #[rstest]
-#[cfg_attr(target_os = "windows", ignore)]
 #[timeout(Duration::from_secs(5))]
 fn f3s10(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;


### PR DESCRIPTION
Adds a trait for the User interface and runs the implementation in a separate thread.
moves interprocess as an optional feature with an IpcUser implementation. This could probably be dropped but the code was already there and felt easy to save.

When a user makes a request to the Daemon, it currently sends a one time use channel to receive a response on. 
I'm not sure I'm particularly happy about this, if for no other reason than it feels weird spawning so many channels but maybe that's okay.
I tried having a separated send and recv channels for the User trait, but i would either end up in a deadlock during testing (with `bounded(0)` channels) or a User implementation would read a message not intended for it (with a `bounded(1)` channel). If that last part is confusing, I mean a `report` request would end up reading the response from a `put` request.

@xpromache  if you have a suggestion about the use channels here I would appreciate it.

fixes #16