### PR TITLE
Compute pdu len

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "byteorder",
  "camino",
  "crossbeam-channel",
+ "dirs",
  "interprocess",
  "itertools",
  "log",
@@ -116,6 +117,7 @@ dependencies = [
  "num-traits",
  "pathdiff",
  "rstest",
+ "rstest_reuse",
  "serialport",
  "signal-hook",
  "tempfile",
@@ -154,6 +156,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -285,6 +307,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -468,6 +501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,12 +525,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -541,6 +621,18 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
+dependencies = [
+ "quote",
+ "rand",
  "rustc_version",
  "syn",
 ]
@@ -702,6 +794,12 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/cfdp-core/Cargo.toml
+++ b/cfdp-core/Cargo.toml
@@ -24,4 +24,6 @@ thiserror = "~1.0"
 
 [dev-dependencies]
 rstest = "0.15.0"
+rstest_reuse = "0.5.0"
 signal-hook = "~0.3"
+dirs = "~4.0"

--- a/cfdp-core/src/daemon.rs
+++ b/cfdp-core/src/daemon.rs
@@ -95,7 +95,7 @@ impl PutRequest {
             buffer.push(vec.len() as u8);
             buffer.extend_from_slice(vec)
         }
-        buffer.push(self.destination_entity_id.get_len());
+        buffer.push(self.destination_entity_id.get_len() as u8);
         buffer.extend(self.destination_entity_id.to_be_bytes());
 
         buffer.push(self.transmission_mode as u8);

--- a/cfdp-core/src/daemon.rs
+++ b/cfdp-core/src/daemon.rs
@@ -95,7 +95,7 @@ impl PutRequest {
             buffer.push(vec.len() as u8);
             buffer.extend_from_slice(vec)
         }
-        buffer.push(self.destination_entity_id.get_len() as u8);
+        buffer.push(self.destination_entity_id.encoded_len() as u8);
         buffer.extend(self.destination_entity_id.to_be_bytes());
 
         buffer.push(self.transmission_mode as u8);

--- a/cfdp-core/src/lib.rs
+++ b/cfdp-core/src/lib.rs
@@ -10,6 +10,11 @@ pub mod user;
 // Re-exported for convenience
 pub use crossbeam_channel::{Receiver, Sender, TryRecvError};
 
+// this import is necessary for the template macro in rstest_reuse as of v0.5.0
+#[cfg(test)]
+#[cfg_attr(test, allow(clippy::single_component_path_imports))]
+use rstest_reuse;
+
 #[cfg(test)]
 mod tests {
 

--- a/cfdp-core/src/pdu.rs
+++ b/cfdp-core/src/pdu.rs
@@ -23,10 +23,10 @@ pub enum PDUPayload {
 }
 impl PDUPayload {
     /// computes the total length of the payload without additional encoding/copying
-    pub fn get_len(&self, file_size_flag: FileSizeFlag) -> u16 {
+    pub fn encoded_len(&self, file_size_flag: FileSizeFlag) -> u16 {
         match self {
-            Self::Directive(operation) => operation.get_len(file_size_flag),
-            Self::FileData(file_data) => file_data.get_len(file_size_flag),
+            Self::Directive(operation) => operation.encoded_len(file_size_flag),
+            Self::FileData(file_data) => file_data.encoded_len(file_size_flag),
         }
     }
 
@@ -66,8 +66,8 @@ pub struct PDU {
 impl PDUEncode for PDU {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        self.header.get_len() + self.payload.get_len(self.header.large_file_flag)
+    fn encoded_len(&self) -> u16 {
+        self.header.encoded_len() + self.payload.encoded_len(self.header.large_file_flag)
     }
 
     fn encode(self) -> Vec<u8> {
@@ -333,7 +333,7 @@ mod test {
         #[values(FileSizeFlag::Small, FileSizeFlag::Large)] file_size_flag: FileSizeFlag,
     ) {
         assert_eq!(
-            payload.get_len(file_size_flag),
+            payload.encoded_len(file_size_flag),
             payload.encode(file_size_flag).len() as u16,
         )
     }
@@ -357,7 +357,7 @@ mod test {
         #[case] payload: PDUPayload,
         #[values(CRCFlag::NotPresent, CRCFlag::Present)] crc_flag: CRCFlag,
     ) -> PDUResult<()> {
-        let pdu_data_field_length = payload.clone().encode(FileSizeFlag::Large).len() as u16;
+        let pdu_data_field_length = payload.encoded_len(FileSizeFlag::Large);
         let pdu_type = match &payload {
             PDUPayload::Directive(_) => PDUType::FileDirective,
             PDUPayload::FileData(_) => PDUType::FileData,

--- a/cfdp-core/src/pdu/fault_handler.rs
+++ b/cfdp-core/src/pdu/fault_handler.rs
@@ -47,7 +47,7 @@ pub struct FaultHandlerOverride {
 impl PDUEncode for FaultHandlerOverride {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         1
     }
 

--- a/cfdp-core/src/pdu/fault_handler.rs
+++ b/cfdp-core/src/pdu/fault_handler.rs
@@ -47,6 +47,10 @@ pub struct FaultHandlerOverride {
 impl PDUEncode for FaultHandlerOverride {
     type PDUType = Self;
 
+    fn get_len(&self) -> u16 {
+        1
+    }
+
     fn encode(self) -> Vec<u8> {
         vec![self.fault_handler_code as u8]
     }

--- a/cfdp-core/src/pdu/filestore.rs
+++ b/cfdp-core/src/pdu/filestore.rs
@@ -247,7 +247,7 @@ pub struct FileStoreRequest {
 impl PDUEncode for FileStoreRequest {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         // action code
         1_u16
         // first name 1 + len
@@ -318,7 +318,7 @@ impl FileStoreResponse {
 impl PDUEncode for FileStoreResponse {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         // Status code
         1
         // First file name length + name (len of str is bytes)

--- a/cfdp-core/src/pdu/filestore.rs
+++ b/cfdp-core/src/pdu/filestore.rs
@@ -246,6 +246,18 @@ pub struct FileStoreRequest {
 }
 impl PDUEncode for FileStoreRequest {
     type PDUType = Self;
+
+    fn get_len(&self) -> u16 {
+        // action code
+        1_u16
+        // first name 1 + len
+        + 1
+        + self.first_filename.as_str().len() as u16
+        // second name 1 + len
+        + 1
+        + self.second_filename.as_str().len() as u16
+    }
+
     fn encode(self) -> Vec<u8> {
         let first_byte = (self.action_code as u8) << 4;
         let mut buffer = vec![first_byte];
@@ -305,6 +317,21 @@ impl FileStoreResponse {
 }
 impl PDUEncode for FileStoreResponse {
     type PDUType = Self;
+
+    fn get_len(&self) -> u16 {
+        // Status code
+        1
+        // First file name length + name (len of str is bytes)
+        + 1
+        + self.first_filename.as_str().len() as u16
+        // Second file name length + name (len of str is bytes)
+        + 1
+        + self.second_filename.as_str().len() as u16
+        // message len + message
+        + 1
+        + self.filestore_message.len() as u16
+    }
+
     fn encode(self) -> Vec<u8> {
         let mut buffer = vec![self.action_and_status.as_u8()];
 

--- a/cfdp-core/src/pdu/user_ops.rs
+++ b/cfdp-core/src/pdu/user_ops.rs
@@ -1463,14 +1463,17 @@ mod test {
             file_status: FileStatusCode::FileStoreRejection
         }
     ))]
-    fn user_op_roundtrip(#[case] expected: UserOperation) {
+    fn user_ops_setup(#[case] expected: UserOperation) {}
+
+    #[apply(user_ops_setup)]
+    fn user_ops_roundtrip(expected: UserOperation) {
         let buffer = expected.clone().encode();
         let recovered = UserOperation::decode(&mut &buffer[..]).unwrap();
 
         assert_eq!(expected, recovered)
     }
 
-    #[apply(user_op_roundtrip)]
+    #[apply(user_ops_setup)]
     fn user_ops_len(expected: UserOperation) {
         assert_eq!(expected.get_len(), expected.encode().len() as u16)
     }

--- a/cfdp-core/src/pdu/user_ops.rs
+++ b/cfdp-core/src/pdu/user_ops.rs
@@ -42,16 +42,16 @@ impl ProxyOperation {
         }
     }
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         match self {
-            Self::ProxyPutRequest(inner) => inner.get_len(),
-            Self::ProxyMessageToUser(inner) => inner.get_len(),
+            Self::ProxyPutRequest(inner) => inner.encoded_len(),
+            Self::ProxyMessageToUser(inner) => inner.encoded_len(),
             // add one here to account for the len field
-            Self::ProxyFileStoreRequest(inner) => 1 + inner.get_len(),
-            Self::ProxyFaultHandlerOverride(inner) => inner.get_len(),
-            Self::ProxyTransmissionMode(inner) => inner.get_len(),
-            Self::ProxyFlowLabel(inner) => inner.get_len(),
-            Self::ProxySegmentationControl(inner) => inner.get_len(),
+            Self::ProxyFileStoreRequest(inner) => 1 + inner.encoded_len(),
+            Self::ProxyFaultHandlerOverride(inner) => inner.encoded_len(),
+            Self::ProxyTransmissionMode(inner) => inner.encoded_len(),
+            Self::ProxyFlowLabel(inner) => inner.encoded_len(),
+            Self::ProxySegmentationControl(inner) => inner.encoded_len(),
             Self::ProxyPutCancel => 0,
         }
     }
@@ -83,14 +83,14 @@ pub enum UserResponse {
     RemoteSuspend(RemoteSuspendResponse),
 }
 impl UserResponse {
-    pub fn get_len(&self) -> u16 {
+    pub fn encoded_len(&self) -> u16 {
         match self {
-            Self::ProxyPut(inner) => inner.get_len(),
-            Self::ProxyFileStore(inner) => 1 + inner.get_len(),
-            Self::DirectoryListing(inner) => inner.get_len(),
-            Self::RemoteStatusReport(inner) => inner.get_len(),
-            Self::RemoteResume(inner) => inner.get_len(),
-            Self::RemoteSuspend(inner) => inner.get_len(),
+            Self::ProxyPut(inner) => inner.encoded_len(),
+            Self::ProxyFileStore(inner) => 1 + inner.encoded_len(),
+            Self::DirectoryListing(inner) => inner.encoded_len(),
+            Self::RemoteStatusReport(inner) => inner.encoded_len(),
+            Self::RemoteResume(inner) => inner.encoded_len(),
+            Self::RemoteSuspend(inner) => inner.encoded_len(),
         }
     }
     pub fn get_message_type(&self) -> MessageType {
@@ -127,12 +127,12 @@ pub enum UserRequest {
     RemoteResume(RemoteResumeRequest),
 }
 impl UserRequest {
-    pub fn get_len(&self) -> u16 {
+    pub fn encoded_len(&self) -> u16 {
         match self {
-            Self::DirectoryListing(inner) => inner.get_len(),
-            Self::RemoteStatusReport(inner) => inner.get_len(),
-            Self::RemoteSuspend(inner) => inner.get_len(),
-            Self::RemoteResume(inner) => inner.get_len(),
+            Self::DirectoryListing(inner) => inner.encoded_len(),
+            Self::RemoteStatusReport(inner) => inner.encoded_len(),
+            Self::RemoteSuspend(inner) => inner.encoded_len(),
+            Self::RemoteResume(inner) => inner.encoded_len(),
         }
     }
     pub fn get_message_type(&self) -> MessageType {
@@ -194,23 +194,23 @@ impl UserOperation {
 impl PDUEncode for UserOperation {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         USER_OPS_IDENTIFIER.len() as u16
             + 1
             + match self {
-                Self::OriginatingTransactionIDMessage(inner) => inner.get_len(),
-                Self::ProxyOperation(inner) => inner.get_len(),
-                Self::Response(inner) => inner.get_len(),
-                Self::Request(inner) => inner.get_len(),
-                Self::SFORequest(inner) => inner.get_len(),
-                Self::SFOMessageToUser(inner) => inner.get_len(),
-                Self::SFOFlowLabel(inner) => inner.get_len(),
-                Self::SFOFaultHandlerOverride(inner) => inner.get_len(),
+                Self::OriginatingTransactionIDMessage(inner) => inner.encoded_len(),
+                Self::ProxyOperation(inner) => inner.encoded_len(),
+                Self::Response(inner) => inner.encoded_len(),
+                Self::Request(inner) => inner.encoded_len(),
+                Self::SFORequest(inner) => inner.encoded_len(),
+                Self::SFOMessageToUser(inner) => inner.encoded_len(),
+                Self::SFOFlowLabel(inner) => inner.encoded_len(),
+                Self::SFOFaultHandlerOverride(inner) => inner.encoded_len(),
                 // add one to accound for the length field
-                Self::SFOFileStoreRequest(inner) => 1 + inner.get_len(),
+                Self::SFOFileStoreRequest(inner) => 1 + inner.encoded_len(),
                 // add one to accound for the length field
-                Self::SFOFileStoreResponse(inner) => 1 + inner.get_len(),
-                Self::SFOReport(inner) => inner.get_len(),
+                Self::SFOFileStoreResponse(inner) => 1 + inner.encoded_len(),
+                Self::SFOReport(inner) => inner.encoded_len(),
             }
     }
     fn encode(self) -> Vec<u8> {
@@ -365,15 +365,15 @@ pub struct OriginatingTransactionIDMessage {
 impl PDUEncode for OriginatingTransactionIDMessage {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        1 + self.source_entity_id.get_len() + self.transaction_sequence_number.get_len()
+    fn encoded_len(&self) -> u16 {
+        1 + self.source_entity_id.encoded_len() + self.transaction_sequence_number.encoded_len()
     }
 
     fn encode(self) -> Vec<u8> {
         let mut buffer: Vec<u8> = vec![];
 
-        let first_byte = (((self.source_entity_id.get_len() as u8 - 1u8) & 0x3) << 4)
-            | ((self.transaction_sequence_number.get_len() as u8 - 1u8) & 0x3);
+        let first_byte = (((self.source_entity_id.encoded_len() as u8 - 1u8) & 0x3) << 4)
+            | ((self.transaction_sequence_number.encoded_len() as u8 - 1u8) & 0x3);
         buffer.push(first_byte);
 
         buffer.extend(self.source_entity_id.to_be_bytes());
@@ -416,15 +416,15 @@ pub struct ProxyPutRequest {
 impl PDUEncode for ProxyPutRequest {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        1 + self.destination_entity_id.get_len()
+    fn encoded_len(&self) -> u16 {
+        1 + self.destination_entity_id.encoded_len()
             + 1
             + self.source_filename.as_str().len() as u16
             + 1
             + self.destination_filename.as_str().len() as u16
     }
     fn encode(self) -> Vec<u8> {
-        let mut buffer = vec![self.destination_entity_id.get_len() as u8];
+        let mut buffer = vec![self.destination_entity_id.encoded_len() as u8];
         buffer.extend(self.destination_entity_id.to_be_bytes());
 
         let source_name = self.source_filename.as_str().as_bytes();
@@ -462,7 +462,7 @@ pub struct ProxyPutResponse {
 impl PDUEncode for ProxyPutResponse {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         1
     }
 
@@ -510,7 +510,7 @@ pub struct ProxySegmentationControl {
 impl PDUEncode for ProxySegmentationControl {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         1
     }
 
@@ -539,7 +539,7 @@ pub struct DirectoryListingRequest {
 impl PDUEncode for DirectoryListingRequest {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         1 + self.directory_name.as_str().len() as u16
             + 1
             + self.directory_filename.as_str().len() as u16
@@ -584,7 +584,7 @@ pub struct DirectoryListingResponse {
 impl PDUEncode for DirectoryListingResponse {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         1 + 1
             + self.directory_name.as_str().len() as u16
             + 1
@@ -635,9 +635,9 @@ pub struct RemoteStatusReportRequest {
 impl PDUEncode for RemoteStatusReportRequest {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        1 + self.source_entity_id.get_len()
-            + self.transaction_sequence_number.get_len()
+    fn encoded_len(&self) -> u16 {
+        1 + self.source_entity_id.encoded_len()
+            + self.transaction_sequence_number.encoded_len()
             + 1
             + self.report_filename.as_str().len() as u16
     }
@@ -645,8 +645,8 @@ impl PDUEncode for RemoteStatusReportRequest {
     fn encode(self) -> Vec<u8> {
         let mut buffer: Vec<u8> = vec![];
 
-        let first_byte = (((self.source_entity_id.get_len() as u8 - 1u8) & 0x3) << 4)
-            | ((self.transaction_sequence_number.get_len() as u8 - 1u8) & 0x3);
+        let first_byte = (((self.source_entity_id.encoded_len() as u8 - 1u8) & 0x3) << 4)
+            | ((self.transaction_sequence_number.encoded_len() as u8 - 1u8) & 0x3);
         buffer.push(first_byte);
 
         buffer.extend(self.source_entity_id.to_be_bytes());
@@ -699,8 +699,8 @@ pub struct RemoteStatusReportResponse {
 impl PDUEncode for RemoteStatusReportResponse {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        1 + 1 + self.source_entity_id.get_len() + self.transaction_sequence_number.get_len()
+    fn encoded_len(&self) -> u16 {
+        1 + 1 + self.source_entity_id.encoded_len() + self.transaction_sequence_number.encoded_len()
     }
 
     fn encode(self) -> Vec<u8> {
@@ -709,8 +709,8 @@ impl PDUEncode for RemoteStatusReportResponse {
         let first_byte: u8 = ((self.transaction_status as u8) << 6) | (self.response_code as u8);
         buffer.push(first_byte);
 
-        let second_byte = (((self.source_entity_id.get_len() as u8 - 1u8) & 0x3) << 4)
-            | ((self.transaction_sequence_number.get_len() as u8 - 1u8) & 0x3);
+        let second_byte = (((self.source_entity_id.encoded_len() as u8 - 1u8) & 0x3) << 4)
+            | ((self.transaction_sequence_number.encoded_len() as u8 - 1u8) & 0x3);
         buffer.push(second_byte);
 
         buffer.extend(self.source_entity_id.to_be_bytes());
@@ -766,15 +766,15 @@ pub struct RemoteSuspendRequest {
 impl PDUEncode for RemoteSuspendRequest {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        1 + self.source_entity_id.get_len() + self.transaction_sequence_number.get_len()
+    fn encoded_len(&self) -> u16 {
+        1 + self.source_entity_id.encoded_len() + self.transaction_sequence_number.encoded_len()
     }
 
     fn encode(self) -> Vec<u8> {
         let mut buffer: Vec<u8> = vec![];
 
-        let first_byte = (((self.source_entity_id.get_len() as u8 - 1u8) & 0x3) << 4)
-            | ((self.transaction_sequence_number.get_len() as u8 - 1u8) & 0x3);
+        let first_byte = (((self.source_entity_id.encoded_len() as u8 - 1u8) & 0x3) << 4)
+            | ((self.transaction_sequence_number.encoded_len() as u8 - 1u8) & 0x3);
         buffer.push(first_byte);
 
         buffer.extend(self.source_entity_id.to_be_bytes());
@@ -820,8 +820,8 @@ pub struct RemoteSuspendResponse {
 impl PDUEncode for RemoteSuspendResponse {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        1 + 1 + self.transaction_sequence_number.get_len() + self.source_entity_id.get_len()
+    fn encoded_len(&self) -> u16 {
+        1 + 1 + self.transaction_sequence_number.encoded_len() + self.source_entity_id.encoded_len()
     }
 
     fn encode(self) -> Vec<u8> {
@@ -831,8 +831,8 @@ impl PDUEncode for RemoteSuspendResponse {
             ((self.suspend_indication as u8) << 7) | ((self.transaction_status as u8) << 5);
         buffer.push(first_byte);
 
-        let second_byte = (((self.source_entity_id.get_len() as u8 - 1u8) & 0x3) << 4)
-            | ((self.transaction_sequence_number.get_len() as u8 - 1u8) & 0x3);
+        let second_byte = (((self.source_entity_id.encoded_len() as u8 - 1u8) & 0x3) << 4)
+            | ((self.transaction_sequence_number.encoded_len() as u8 - 1u8) & 0x3);
         buffer.push(second_byte);
 
         buffer.extend(self.source_entity_id.to_be_bytes());
@@ -887,15 +887,15 @@ pub struct RemoteResumeRequest {
 impl PDUEncode for RemoteResumeRequest {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        1 + self.source_entity_id.get_len() + self.transaction_sequence_number.get_len()
+    fn encoded_len(&self) -> u16 {
+        1 + self.source_entity_id.encoded_len() + self.transaction_sequence_number.encoded_len()
     }
 
     fn encode(self) -> Vec<u8> {
         let mut buffer: Vec<u8> = vec![];
 
-        let first_byte = (((self.source_entity_id.get_len() as u8 - 1u8) & 0x3) << 4)
-            | ((self.transaction_sequence_number.get_len() as u8 - 1u8) & 0x3);
+        let first_byte = (((self.source_entity_id.encoded_len() as u8 - 1u8) & 0x3) << 4)
+            | ((self.transaction_sequence_number.encoded_len() as u8 - 1u8) & 0x3);
         buffer.push(first_byte);
 
         buffer.extend(self.source_entity_id.to_be_bytes());
@@ -940,8 +940,8 @@ pub struct RemoteResumeResponse {
 impl PDUEncode for RemoteResumeResponse {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
-        1 + 1 + self.source_entity_id.get_len() + self.transaction_sequence_number.get_len()
+    fn encoded_len(&self) -> u16 {
+        1 + 1 + self.source_entity_id.encoded_len() + self.transaction_sequence_number.encoded_len()
     }
 
     fn encode(self) -> Vec<u8> {
@@ -951,8 +951,8 @@ impl PDUEncode for RemoteResumeResponse {
             ((self.suspend_indication as u8) << 7) | ((self.transaction_status as u8) << 5);
         buffer.push(first_byte);
 
-        let second_byte = (((self.source_entity_id.get_len() as u8 - 1u8) & 0x3) << 4)
-            | ((self.transaction_sequence_number.get_len() as u8 - 1u8) & 0x3);
+        let second_byte = (((self.source_entity_id.encoded_len() as u8 - 1u8) & 0x3) << 4)
+            | ((self.transaction_sequence_number.encoded_len() as u8 - 1u8) & 0x3);
         buffer.push(second_byte);
 
         buffer.extend(self.source_entity_id.to_be_bytes());
@@ -1014,7 +1014,7 @@ pub struct SFORequest {
 impl PDUEncode for SFORequest {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         // trace control, transmission mode, segment mode and closure reques
         1
         // prior way points
@@ -1123,7 +1123,7 @@ pub struct SFOReport {
 impl PDUEncode for SFOReport {
     type PDUType = Self;
 
-    fn get_len(&self) -> u16 {
+    fn encoded_len(&self) -> u16 {
         // label len + message
         1 + self.request_label.len() as u16
         // source entity id len + valu
@@ -1475,6 +1475,6 @@ mod test {
 
     #[apply(user_ops_setup)]
     fn user_ops_len(expected: UserOperation) {
-        assert_eq!(expected.get_len(), expected.encode().len() as u16)
+        assert_eq!(expected.encoded_len(), expected.encode().len() as u16)
     }
 }

--- a/cfdp-core/src/transaction/send.rs
+++ b/cfdp-core/src/transaction/send.rs
@@ -391,11 +391,7 @@ impl<T: FileStore> SendTransaction<T> {
 
         let payload = PDUPayload::FileData(data);
 
-        let payload_len: u16 = payload
-            .clone()
-            .encode(self.config.file_size_flag)
-            .len()
-            .try_into()?;
+        let payload_len: u16 = payload.get_len(self.config.file_size_flag);
 
         let header = self.get_header(
             Direction::ToReceiver,
@@ -465,7 +461,7 @@ impl<T: FileStore> SendTransaction<T> {
             self.timer.restart_ack();
 
             let payload = PDUPayload::Directive(Operations::EoF(eof.clone()));
-            let payload_len = payload.clone().encode(self.config.file_size_flag).len() as u16;
+            let payload_len = payload.get_len(self.config.file_size_flag);
             let header = self.get_header(
                 Direction::ToReceiver,
                 PDUType::FileDirective,
@@ -576,7 +572,7 @@ impl<T: FileStore> SendTransaction<T> {
     fn send_ack(&mut self, transport_tx: &Sender<(VariableID, PDU)>) -> TransactionResult<()> {
         if let Some(ack) = self.ack.take() {
             let payload = PDUPayload::Directive(Operations::Ack(ack));
-            let payload_len = payload.clone().encode(self.config.file_size_flag).len() as u16;
+            let payload_len = payload.get_len(self.config.file_size_flag);
 
             let header = self.get_header(
                 Direction::ToReceiver,
@@ -852,11 +848,7 @@ impl<T: FileStore> SendTransaction<T> {
         };
 
         let payload = PDUPayload::Directive(Operations::Metadata(metadata));
-        let payload_len: u16 = payload
-            .clone()
-            .encode(self.config.file_size_flag)
-            .len()
-            .try_into()?;
+        let payload_len: u16 = payload.get_len(self.config.file_size_flag);
 
         let header = self.get_header(
             Direction::ToReceiver,
@@ -979,15 +971,12 @@ mod test {
             offset: 6,
             file_data: input.clone(),
         }));
-        let payload_len = payload
-            .clone()
-            .encode(transaction.config.file_size_flag)
-            .len();
+        let payload_len = payload.get_len(transaction.config.file_size_flag);
 
         let header = transaction.get_header(
             Direction::ToReceiver,
             PDUType::FileData,
-            payload_len as u16,
+            payload_len,
             SegmentationControl::NotPreserved,
         );
         let pdu = PDU { header, payload };
@@ -1053,15 +1042,12 @@ mod test {
                     offset: 6,
                     file_data: input.clone(),
                 }));
-                let payload_len = payload
-                    .clone()
-                    .encode(transaction.config.file_size_flag)
-                    .len();
+                let payload_len = payload.get_len(transaction.config.file_size_flag);
 
                 let header = transaction.get_header(
                     Direction::ToReceiver,
                     PDUType::FileData,
-                    payload_len as u16,
+                    payload_len,
                     SegmentationControl::NotPreserved,
                 );
                 PDU { header, payload }
@@ -1075,15 +1061,12 @@ mod test {
                     destination_filename: path.as_str().as_bytes().to_vec(),
                     options: vec![],
                 }));
-                let payload_len = payload
-                    .clone()
-                    .encode(transaction.config.file_size_flag)
-                    .len();
+                let payload_len = payload.get_len(transaction.config.file_size_flag);
 
                 let header = transaction.get_header(
                     Direction::ToReceiver,
                     PDUType::FileDirective,
-                    payload_len as u16,
+                    payload_len,
                     SegmentationControl::NotPreserved,
                 );
                 PDU { header, payload }
@@ -1179,15 +1162,12 @@ mod test {
             file_size: input.as_bytes().len() as u64,
             fault_location: None,
         }));
-        let payload_len = payload
-            .clone()
-            .encode(transaction.config.file_size_flag)
-            .len();
+        let payload_len = payload.get_len(transaction.config.file_size_flag);
 
         let header = transaction.get_header(
             Direction::ToReceiver,
             PDUType::FileDirective,
-            payload_len as u16,
+            payload_len,
             SegmentationControl::NotPreserved,
         );
         let pdu = PDU { header, payload };
@@ -1259,12 +1239,12 @@ mod test {
             file_size: input.as_bytes().len() as u64,
             fault_location: Some(config.source_entity_id),
         }));
-        let payload_len = payload.clone().encode(config.file_size_flag).len();
+        let payload_len = payload.get_len(config.file_size_flag);
 
         let header = transaction.get_header(
             Direction::ToReceiver,
             PDUType::FileDirective,
-            payload_len as u16,
+            payload_len,
             SegmentationControl::NotPreserved,
         );
         let pdu = PDU { header, payload };
@@ -1391,12 +1371,12 @@ mod test {
             transaction_status: transaction.status.clone(),
         }));
 
-        let payload_len = payload.clone().encode(config.file_size_flag).len();
+        let payload_len = payload.get_len(config.file_size_flag);
 
         let header = transaction.get_header(
             Direction::ToReceiver,
             PDUType::FileDirective,
-            payload_len as u16,
+            payload_len,
             SegmentationControl::NotPreserved,
         );
         let pdu = PDU { header, payload };
@@ -1479,10 +1459,7 @@ mod test {
         let mut transaction = SendTransaction::new(config, metadata, filestore, sender);
 
         let payload = PDUPayload::Directive(operation);
-        let payload_len = payload
-            .clone()
-            .encode(transaction.config.file_size_flag)
-            .len() as u16;
+        let payload_len = payload.get_len(transaction.config.file_size_flag);
         let header = transaction.get_header(
             Direction::ToSender,
             PDUType::FileDirective,
@@ -1546,10 +1523,7 @@ mod test {
         let mut transaction = SendTransaction::new(config, metadata, filestore, sender);
 
         let payload = PDUPayload::Directive(operation);
-        let payload_len = payload
-            .clone()
-            .encode(transaction.config.file_size_flag)
-            .len() as u16;
+        let payload_len = payload.get_len(transaction.config.file_size_flag);
         let header = transaction.get_header(
             Direction::ToSender,
             PDUType::FileDirective,
@@ -1592,10 +1566,7 @@ mod test {
             offset: 12_u64,
             file_data: (0..12_u8).collect::<Vec<u8>>(),
         }));
-        let payload_len = payload
-            .clone()
-            .encode(transaction.config.file_size_flag)
-            .len() as u16;
+        let payload_len = payload.get_len(transaction.config.file_size_flag);
         let header = transaction.get_header(
             Direction::ToSender,
             PDUType::FileData,
@@ -1633,10 +1604,7 @@ mod test {
                 filestore_response: vec![],
                 fault_location: None,
             }));
-            let payload_len = payload
-                .clone()
-                .encode(transaction.config.file_size_flag)
-                .len() as u16;
+            let payload_len = payload.get_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToSender,
@@ -1655,10 +1623,7 @@ mod test {
                 directive_subtype_code: ACKSubDirective::Finished,
                 transaction_status: TransactionStatus::Undefined,
             }));
-            let payload_len = payload
-                .clone()
-                .encode(transaction.config.file_size_flag)
-                .len() as u16;
+            let payload_len = payload.get_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToReceiver,
@@ -1712,10 +1677,7 @@ mod test {
                     end_offset: total_size,
                 }],
             }));
-            let payload_len = payload
-                .clone()
-                .encode(transaction.config.file_size_flag)
-                .len() as u16;
+            let payload_len = payload.get_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToSender,
@@ -1784,10 +1746,7 @@ mod test {
                 directive_subtype_code: ACKSubDirective::Other,
                 transaction_status: TransactionStatus::Undefined,
             }));
-            let payload_len = payload
-                .clone()
-                .encode(transaction.config.file_size_flag)
-                .len() as u16;
+            let payload_len = payload.get_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToSender,
@@ -1806,10 +1765,7 @@ mod test {
                 file_size: 500,
                 fault_location: None,
             }));
-            let payload_len = payload
-                .clone()
-                .encode(transaction.config.file_size_flag)
-                .len() as u16;
+            let payload_len = payload.get_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToReceiver,
@@ -1861,10 +1817,7 @@ mod test {
         let keep_alive = {
             let payload =
                 PDUPayload::Directive(Operations::KeepAlive(KeepAlivePDU { progress: 300 }));
-            let payload_len = payload
-                .clone()
-                .encode(transaction.config.file_size_flag)
-                .len() as u16;
+            let payload_len = payload.get_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToSender,

--- a/cfdp-core/src/transaction/send.rs
+++ b/cfdp-core/src/transaction/send.rs
@@ -391,7 +391,7 @@ impl<T: FileStore> SendTransaction<T> {
 
         let payload = PDUPayload::FileData(data);
 
-        let payload_len: u16 = payload.get_len(self.config.file_size_flag);
+        let payload_len: u16 = payload.encoded_len(self.config.file_size_flag);
 
         let header = self.get_header(
             Direction::ToReceiver,
@@ -461,7 +461,7 @@ impl<T: FileStore> SendTransaction<T> {
             self.timer.restart_ack();
 
             let payload = PDUPayload::Directive(Operations::EoF(eof.clone()));
-            let payload_len = payload.get_len(self.config.file_size_flag);
+            let payload_len = payload.encoded_len(self.config.file_size_flag);
             let header = self.get_header(
                 Direction::ToReceiver,
                 PDUType::FileDirective,
@@ -572,7 +572,7 @@ impl<T: FileStore> SendTransaction<T> {
     fn send_ack(&mut self, transport_tx: &Sender<(VariableID, PDU)>) -> TransactionResult<()> {
         if let Some(ack) = self.ack.take() {
             let payload = PDUPayload::Directive(Operations::Ack(ack));
-            let payload_len = payload.get_len(self.config.file_size_flag);
+            let payload_len = payload.encoded_len(self.config.file_size_flag);
 
             let header = self.get_header(
                 Direction::ToReceiver,
@@ -848,7 +848,7 @@ impl<T: FileStore> SendTransaction<T> {
         };
 
         let payload = PDUPayload::Directive(Operations::Metadata(metadata));
-        let payload_len: u16 = payload.get_len(self.config.file_size_flag);
+        let payload_len: u16 = payload.encoded_len(self.config.file_size_flag);
 
         let header = self.get_header(
             Direction::ToReceiver,
@@ -971,7 +971,7 @@ mod test {
             offset: 6,
             file_data: input.clone(),
         }));
-        let payload_len = payload.get_len(transaction.config.file_size_flag);
+        let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
         let header = transaction.get_header(
             Direction::ToReceiver,
@@ -1042,7 +1042,7 @@ mod test {
                     offset: 6,
                     file_data: input.clone(),
                 }));
-                let payload_len = payload.get_len(transaction.config.file_size_flag);
+                let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
                 let header = transaction.get_header(
                     Direction::ToReceiver,
@@ -1061,7 +1061,7 @@ mod test {
                     destination_filename: path.as_str().as_bytes().to_vec(),
                     options: vec![],
                 }));
-                let payload_len = payload.get_len(transaction.config.file_size_flag);
+                let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
                 let header = transaction.get_header(
                     Direction::ToReceiver,
@@ -1162,7 +1162,7 @@ mod test {
             file_size: input.as_bytes().len() as u64,
             fault_location: None,
         }));
-        let payload_len = payload.get_len(transaction.config.file_size_flag);
+        let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
         let header = transaction.get_header(
             Direction::ToReceiver,
@@ -1239,7 +1239,7 @@ mod test {
             file_size: input.as_bytes().len() as u64,
             fault_location: Some(config.source_entity_id),
         }));
-        let payload_len = payload.get_len(config.file_size_flag);
+        let payload_len = payload.encoded_len(config.file_size_flag);
 
         let header = transaction.get_header(
             Direction::ToReceiver,
@@ -1371,7 +1371,7 @@ mod test {
             transaction_status: transaction.status.clone(),
         }));
 
-        let payload_len = payload.get_len(config.file_size_flag);
+        let payload_len = payload.encoded_len(config.file_size_flag);
 
         let header = transaction.get_header(
             Direction::ToReceiver,
@@ -1459,7 +1459,7 @@ mod test {
         let mut transaction = SendTransaction::new(config, metadata, filestore, sender);
 
         let payload = PDUPayload::Directive(operation);
-        let payload_len = payload.get_len(transaction.config.file_size_flag);
+        let payload_len = payload.encoded_len(transaction.config.file_size_flag);
         let header = transaction.get_header(
             Direction::ToSender,
             PDUType::FileDirective,
@@ -1523,7 +1523,7 @@ mod test {
         let mut transaction = SendTransaction::new(config, metadata, filestore, sender);
 
         let payload = PDUPayload::Directive(operation);
-        let payload_len = payload.get_len(transaction.config.file_size_flag);
+        let payload_len = payload.encoded_len(transaction.config.file_size_flag);
         let header = transaction.get_header(
             Direction::ToSender,
             PDUType::FileDirective,
@@ -1566,7 +1566,7 @@ mod test {
             offset: 12_u64,
             file_data: (0..12_u8).collect::<Vec<u8>>(),
         }));
-        let payload_len = payload.get_len(transaction.config.file_size_flag);
+        let payload_len = payload.encoded_len(transaction.config.file_size_flag);
         let header = transaction.get_header(
             Direction::ToSender,
             PDUType::FileData,
@@ -1604,7 +1604,7 @@ mod test {
                 filestore_response: vec![],
                 fault_location: None,
             }));
-            let payload_len = payload.get_len(transaction.config.file_size_flag);
+            let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToSender,
@@ -1623,7 +1623,7 @@ mod test {
                 directive_subtype_code: ACKSubDirective::Finished,
                 transaction_status: TransactionStatus::Undefined,
             }));
-            let payload_len = payload.get_len(transaction.config.file_size_flag);
+            let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToReceiver,
@@ -1677,7 +1677,7 @@ mod test {
                     end_offset: total_size,
                 }],
             }));
-            let payload_len = payload.get_len(transaction.config.file_size_flag);
+            let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToSender,
@@ -1746,7 +1746,7 @@ mod test {
                 directive_subtype_code: ACKSubDirective::Other,
                 transaction_status: TransactionStatus::Undefined,
             }));
-            let payload_len = payload.get_len(transaction.config.file_size_flag);
+            let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToSender,
@@ -1765,7 +1765,7 @@ mod test {
                 file_size: 500,
                 fault_location: None,
             }));
-            let payload_len = payload.get_len(transaction.config.file_size_flag);
+            let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToReceiver,
@@ -1817,7 +1817,7 @@ mod test {
         let keep_alive = {
             let payload =
                 PDUPayload::Directive(Operations::KeepAlive(KeepAlivePDU { progress: 300 }));
-            let payload_len = payload.get_len(transaction.config.file_size_flag);
+            let payload_len = payload.encoded_len(transaction.config.file_size_flag);
 
             let header = transaction.get_header(
                 Direction::ToSender,

--- a/cfdp-core/tests/series_f3.rs
+++ b/cfdp-core/tests/series_f3.rs
@@ -67,7 +67,7 @@ fn f3s01(get_filestore: &UsersAndFilestore) {
 //  - Acknowledged
 //  - Create New file on remote
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s02(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
@@ -103,7 +103,7 @@ fn f3s02(get_filestore: &UsersAndFilestore) {
 //  - Acknowledged
 //  - Create New file on remote, then delete it with another transaction
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s03(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
@@ -175,7 +175,7 @@ fn f3s03(get_filestore: &UsersAndFilestore) {
 //  - Acknowledged
 //  - Create New file on remote, then Rename it in another transaction
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s04(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
@@ -254,7 +254,7 @@ fn f3s04(get_filestore: &UsersAndFilestore) {
 //  - Transfer M file
 //  - Append new file to first file
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s05(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
@@ -348,7 +348,7 @@ fn f3s05(get_filestore: &UsersAndFilestore) {
 //  - Transfer M file
 //  - Replace small file with medium file
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s06(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
@@ -433,7 +433,7 @@ fn f3s06(get_filestore: &UsersAndFilestore) {
 //  - Acknowledged
 //  - Create new directory
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s07(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
@@ -472,7 +472,7 @@ fn f3s07(get_filestore: &UsersAndFilestore) {
 //  - Create new directory
 //  - Then remove it
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s08(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
@@ -532,7 +532,7 @@ fn f3s08(get_filestore: &UsersAndFilestore) {
 //  - Send M file
 //  - Then DenyFile and verify it is removed
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s09(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
@@ -588,7 +588,7 @@ fn f3s09(get_filestore: &UsersAndFilestore) {
 //  - Send Directory listing request
 //  - verify the listing file is created
 #[rstest]
-#[timeout(Duration::from_secs(5))]
+#[timeout(Duration::from_secs(10))]
 fn f3s10(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 


### PR DESCRIPTION
adds a get_len method to all the encoding Traits to skip encoding.

~~I think there's still some test coverage missing on some MetadataTLV types~~


fixes #13 