### PR TITLE
Pass NakProcedure to RecvTransaction

### DIFF
--- a/cfdp-core/src/daemon.rs
+++ b/cfdp-core/src/daemon.rs
@@ -641,7 +641,8 @@ impl<T: FileStore + Send + Sync + 'static> Daemon<T> {
             "({:?}, {:?})",
             &config.source_entity_id, &config.sequence_number
         );
-        let mut transaction = RecvTransaction::new(config, filestore, message_tx);
+        let mut transaction =
+            RecvTransaction::new(config, entity_config.nak_procedure, filestore, message_tx);
         let id = transaction.id();
 
         let handle = thread::Builder::new().name(name).spawn(move || {

--- a/cfdp-core/src/transaction/recv.rs
+++ b/cfdp-core/src/transaction/recv.rs
@@ -101,7 +101,7 @@ impl<T: FileStore> RecvTransaction<T> {
     pub fn new(
         // Configuation of this Transaction.
         config: TransactionConfig,
-        // Desired NAK procedure. This is most likely passed from and EntityConfig
+        // Desired NAK procedure. This is most likely passed from an EntityConfig
         nak_procedure: NakProcedure,
         // Connection to the local FileStore implementation.
         filestore: Arc<T>,

--- a/cfdp-core/src/user.rs
+++ b/cfdp-core/src/user.rs
@@ -334,7 +334,10 @@ mod ipc {
                     .primitive_handler(signal, sender)
                     .expect("Err in daemon user half.");
             });
-            thread::sleep(Duration::from_millis(5));
+
+            while !ipc_user.socket.as_std_path().exists() {
+                thread::sleep(Duration::from_millis(5));
+            }
             assert!(ipc_user.socket.as_std_path().exists());
 
             (ipc_user, handle, receiver)


### PR DESCRIPTION
Allows the RecvTransaction to be constructed with a NakProcedure. Pass procedures from the EntityConfig for the remote