### PR TITLE
allocate from the beginning the buffer of the right size

### DIFF
--- a/cfdp-core/src/transaction/send.rs
+++ b/cfdp-core/src/transaction/send.rs
@@ -356,7 +356,7 @@ impl<T: FileStore> SendTransaction<T> {
 
         // use take to limit the final segment from trying to read past the EoF.
         let data = {
-            let mut buff = Vec::<u8>::new();
+            let mut buff = Vec::<u8>::with_capacity(length as usize);
             handle
                 .take(length as u64)
                 .read_to_end(&mut buff)


### PR DESCRIPTION
Except when reading from the end of the file this will be the right size. The read_to_end does not know how much it has to read so it will allocate first 32 bytes, then 64...