### PR TITLE
Changed TransactionID into a struct

### DIFF
--- a/cfdp-core/src/pdu/ops.rs
+++ b/cfdp-core/src/pdu/ops.rs
@@ -91,6 +91,14 @@ impl VariableID {
             VariableID::U64(val) => val.to_be_bytes().to_vec(),
         }
     }
+    pub fn to_u64(&self) -> u64 {
+        match self {
+            VariableID::U8(val) => *val as u64,
+            VariableID::U16(val) => *val as u64,
+            VariableID::U32(val) => *val as u64,
+            VariableID::U64(val) => *val,
+        }
+    }
 }
 impl PDUEncode for VariableID {
     type PDUType = Self;

--- a/cfdp-core/src/transaction/config.rs
+++ b/cfdp-core/src/transaction/config.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 use camino::Utf8PathBuf;
 use num_derive::FromPrimitive;
@@ -7,11 +7,29 @@ use crate::{
     filestore::ChecksumType,
     pdu::{
         CRCFlag, Condition, EntityID, FaultHandlerAction, FileSizeFlag, FileStoreRequest,
-        MessageToUser, SegmentedData, TransactionSeqNum, TransmissionMode,
+        MessageToUser, SegmentedData, TransactionSeqNum, TransmissionMode, VariableID,
     },
 };
 
-pub type TransactionID = (EntityID, TransactionSeqNum);
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct TransactionID(pub EntityID, pub TransactionSeqNum);
+
+impl fmt::Display for TransactionID {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}", self.0.to_u64(), self.1.to_u64())
+    }
+}
+
+impl TransactionID {
+    pub fn from<T, U>(entity_id: T, seq_num: U) -> Self
+    where
+        VariableID: From<T>,
+        VariableID: From<U>,
+    {
+        Self(EntityID::from(entity_id), TransactionSeqNum::from(seq_num))
+    }
+}
 
 #[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]

--- a/cfdp-core/src/user.rs
+++ b/cfdp-core/src/user.rs
@@ -102,7 +102,7 @@ mod ipc {
                 let mut connection = LocalSocketStream::connect(self.socket.as_str())?;
                 connection.write_all(primitive.encode().as_slice())?;
 
-                (
+                TransactionID(
                     EntityID::decode(&mut connection)
                         .map_err(|_| IoError::from(ErrorKind::InvalidData))?,
                     TransactionSeqNum::decode(&mut connection)
@@ -114,22 +114,22 @@ mod ipc {
 
         /// Suspend the input transactin
         pub fn suspend(&self, transaction: TransactionID) -> Result<(), IoError> {
-            self.send(UserPrimitive::Suspend(transaction.0, transaction.1))
+            self.send(UserPrimitive::Suspend(transaction))
         }
 
         /// Resume the input transaction
         pub fn resume(&self, transaction: TransactionID) -> Result<(), IoError> {
-            self.send(UserPrimitive::Resume(transaction.0, transaction.1))
+            self.send(UserPrimitive::Resume(transaction))
         }
 
         /// Cancel the input transaction
         pub fn cancel(&self, transaction: TransactionID) -> Result<(), IoError> {
-            self.send(UserPrimitive::Cancel(transaction.0, transaction.1))
+            self.send(UserPrimitive::Cancel(transaction))
         }
 
         /// Receive the latest [Report] for the given transaction.
         pub fn report(&self, transaction: TransactionID) -> Result<Option<Report>, IoError> {
-            let primitive = UserPrimitive::Report(transaction.0, transaction.1);
+            let primitive = UserPrimitive::Report(transaction);
 
             let report = {
                 let mut connection = LocalSocketStream::connect(self.socket.as_str())?;
@@ -207,7 +207,7 @@ mod ipc {
                                     )?;
                                 }
                             }
-                            UserPrimitive::Cancel(_, _) => {
+                            UserPrimitive::Cancel(_) => {
                                 sender.send((primitive, internal_send)).map_err(|_| {
                                     IoError::new(
                                         ErrorKind::ConnectionReset,
@@ -215,7 +215,7 @@ mod ipc {
                                     )
                                 })?
                             }
-                            UserPrimitive::Suspend(_, _) => {
+                            UserPrimitive::Suspend(_) => {
                                 sender.send((primitive, internal_send)).map_err(|_| {
                                     IoError::new(
                                         ErrorKind::ConnectionReset,
@@ -223,7 +223,7 @@ mod ipc {
                                     )
                                 })?
                             }
-                            UserPrimitive::Resume(_, _) => {
+                            UserPrimitive::Resume(_) => {
                                 sender.send((primitive, internal_send)).map_err(|_| {
                                     IoError::new(
                                         ErrorKind::ConnectionReset,
@@ -231,7 +231,7 @@ mod ipc {
                                     )
                                 })?
                             }
-                            UserPrimitive::Report(_, _) => {
+                            UserPrimitive::Report(_) => {
                                 sender.send((primitive, internal_send)).map_err(|_| {
                                     IoError::new(
                                         ErrorKind::ConnectionReset,

--- a/cfdp-core/tests/common/mod.rs
+++ b/cfdp-core/tests/common/mod.rs
@@ -101,7 +101,7 @@ impl TestUserHalf {
     // apparently related https://github.com/rust-lang/rust/issues/46379
     #[allow(unused)]
     pub fn cancel(&self, transaction: TransactionID) -> Result<(), IoError> {
-        let primitive = UserPrimitive::Cancel(transaction.0, transaction.1);
+        let primitive = UserPrimitive::Cancel(transaction);
         let (send, _recv) = bounded(0);
         self.internal_tx.send((primitive, send)).map_err(|_| {
             IoError::new(
@@ -112,7 +112,7 @@ impl TestUserHalf {
     }
 
     pub fn report(&self, transaction: TransactionID) -> Result<Option<Report>, IoError> {
-        let primitive = UserPrimitive::Report(transaction.0, transaction.1);
+        let primitive = UserPrimitive::Report(transaction);
         let (send, recv) = bounded(0);
 
         self.internal_tx.send((primitive, send)).map_err(|_| {
@@ -170,7 +170,7 @@ impl User for TestDaemonHalf {
                                 )
                             })?;
                         }
-                        UserPrimitive::Cancel(_, _) => {
+                        UserPrimitive::Cancel(_) => {
                             sender.send((primitive, internal_send)).map_err(|_| {
                                 IoError::new(
                                     ErrorKind::ConnectionReset,
@@ -178,7 +178,7 @@ impl User for TestDaemonHalf {
                                 )
                             })?
                         }
-                        UserPrimitive::Suspend(_, _) => {
+                        UserPrimitive::Suspend(_) => {
                             sender.send((primitive, internal_send)).map_err(|_| {
                                 IoError::new(
                                     ErrorKind::ConnectionReset,
@@ -186,7 +186,7 @@ impl User for TestDaemonHalf {
                                 )
                             })?
                         }
-                        UserPrimitive::Resume(_, _) => {
+                        UserPrimitive::Resume(_) => {
                             sender.send((primitive, internal_send)).map_err(|_| {
                                 IoError::new(
                                     ErrorKind::ConnectionReset,
@@ -194,7 +194,7 @@ impl User for TestDaemonHalf {
                                 )
                             })?
                         }
-                        UserPrimitive::Report(_, _) => {
+                        UserPrimitive::Report(_) => {
                             sender.send((primitive, internal_send)).map_err(|_| {
                                 IoError::new(
                                     ErrorKind::ConnectionReset,


### PR DESCRIPTION
What started as an innocent wish to have the transaction id show better in the logs (because one cannot implement fmt::Display for a tuple), turned out into a lot of changes.

But I think the TransactionID was important enought to deserve its own struct.