### PR TITLE
Update PDUtransport trait

### DIFF
--- a/cfdp-core/src/filestore.rs
+++ b/cfdp-core/src/filestore.rs
@@ -126,7 +126,7 @@ pub trait FileStore {
     fn get_size<P: AsRef<Utf8Path>>(&self, path: P) -> FileStoreResult<u64>;
 
     /// Executes an action based on an input filestore request
-    /// This is meant to be executed by a Transaction
+    /// This is meant to be executed by a [Send](crate::transaction::SendTransaction) or [Recv](crate::transaction::RecvTransaction) transaction.
     /// instance which requires errors be mapped to a status.
     fn process_request(&self, request: &FileStoreRequest) -> FileStoreResponse {
         let path = self.get_native_path(&request.first_filename);

--- a/cfdp-daemon/src/transaction/send.rs
+++ b/cfdp-daemon/src/transaction/send.rs
@@ -738,15 +738,12 @@ impl<T: FileStore> SendTransaction<T> {
                                 delivery_code: self.delivery_code,
                             }));
 
-                            match self.condition != Condition::NoError {
-                                true => {
-                                    info!(
-                                        "Transaction {}. Ended due to condition {:?}",
-                                        self.id(),
-                                        self.condition
-                                    );
-                                }
-                                false => {}
+                            if self.condition != Condition::NoError {
+                                info!(
+                                    "Transaction {}. Ended due to condition {:?}",
+                                    self.id(),
+                                    self.condition
+                                );
                             }
                             Ok(())
                         }

--- a/cfdp-daemon/src/transaction/send.rs
+++ b/cfdp-daemon/src/transaction/send.rs
@@ -1087,11 +1087,12 @@ mod test {
     }
 
     #[rstest]
-    #[case(SegmentRequestForm { start_offset: 6, end_offset: 10 })]
-    #[case(SegmentRequestForm { start_offset: 0, end_offset: 0 })]
+    #[case(SegmentRequestForm { start_offset: 6, end_offset: 10 }, "testfile_missing1")]
+    #[case(SegmentRequestForm { start_offset: 0, end_offset: 0 }, "testfile_missing2")]
     #[tokio::test]
     async fn send_missing(
         #[case] nak: SegmentRequestForm,
+        #[case] filename: &str,
         default_config: &TransactionConfig,
         tempdir_fixture: &TempDir,
     ) {
@@ -1101,7 +1102,7 @@ mod test {
             Utf8Path::from_path(tempdir_fixture.path()).expect("Unable to make utf8 tempdir"),
         ));
 
-        let path = Utf8PathBuf::from("testfile_missing");
+        let path = Utf8PathBuf::from(filename);
         let metadata = test_metadata(10, path.clone());
 
         let (indication_tx, _indication_rx) = channel(10);

--- a/cfdp-daemon/src/transaction/send.rs
+++ b/cfdp-daemon/src/transaction/send.rs
@@ -387,7 +387,7 @@ impl<T: FileStore> SendTransaction<T> {
         offset: Option<u64>,
         length: Option<u16>,
     ) -> TransactionResult<(u64, Vec<u8>)> {
-        // use the maximum size for the receiever if no length is given
+        // use the maximum size for the receiver if no length is given
         let length = length.unwrap_or(self.config.file_size_segment);
         let handle = self.get_handle()?;
         // if no offset given read from current cursor position

--- a/cfdp-daemon/src/transport.rs
+++ b/cfdp-daemon/src/transport.rs
@@ -7,7 +7,6 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -72,8 +71,6 @@ pub trait PDUTransport {
                     break
                 }
             }
-            // this should be at minimum made configurable
-            tokio::time::sleep(Duration::from_micros(100)).await;
         }
         Ok(())
     }


### PR DESCRIPTION
Removes the `request` method from PDUTransport. The only required method now is `pdu_handler`, each implementation can handle sending and receiving however it likes. i imagine this is the function you were referencing @xpromache ?

Fixed up a few docs spots referencing older structs too.

closes #39 