### PR TITLE
Add Prompt primitive

### DIFF
--- a/cfdp-core/src/transaction/send.rs
+++ b/cfdp-core/src/transaction/send.rs
@@ -82,7 +82,7 @@ pub struct SendTransaction<T: FileStore> {
     eof: Option<(EndOfFile, bool)>,
     /// Acknowledgement PDU prepared to be sent at next opportunity.
     ack: Option<PositiveAcknowledgePDU>,
-    /// A PromptPDU to be send at the next available opporunity.
+    /// A PromptPDU to be sent at the next available opportunity.
     prompt: Option<PromptPDU>,
     /// Channel for Indications to propagate back up
     indication_tx: Sender<Indication>,


### PR DESCRIPTION
Adds a prompt primitive to trigger a prompt NAK or prompt KeepAlive PDU from the mission specific User process.

I tried to be maximally flexible about when prompts could be generated in the Send, but it just ended up being the highest priority PDU for the Send transaction. At first I was not totally sold on the idea, but it mirrors the Recv's handling of prompt so maybe it is okay. I also figure, if the mission is trying to send a Prompt it should be handle ASAP.

thoughts @xpromache ?

closes #34 