### PR TITLE
remove duplicated code

### DIFF
--- a/cfdp-core/tests/series_f1.rs
+++ b/cfdp-core/tests/series_f1.rs
@@ -34,10 +34,10 @@ use common::{
 // Configuration:
 //  - Unacknowledged
 //  - File Size: Small (file fits in single pdu)
-fn f1s1(get_filestore: &UsersAndFilestore) {
+fn f1s01(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/small_f1s1.txt".into();
+    let out_file: Utf8PathBuf = "remote/small_f1s01.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -66,10 +66,10 @@ fn f1s1(get_filestore: &UsersAndFilestore) {
 // Configuration:
 //  - Unacknowledged
 //  - File Size: Medium
-fn f1s2(get_filestore: &UsersAndFilestore) {
+fn f1s02(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s2.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s02.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -98,10 +98,10 @@ fn f1s2(get_filestore: &UsersAndFilestore) {
 // Configuration:
 //  - Acknowledged
 //  - File Size: Medium
-fn f1s3(get_filestore: &UsersAndFilestore) {
+fn f1s03(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s3.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s03.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -124,7 +124,7 @@ fn f1s3(get_filestore: &UsersAndFilestore) {
 
 #[fixture]
 #[once]
-fn fixture_f1s4(
+fn fixture_f1s04(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -180,9 +180,9 @@ fn fixture_f1s4(
 //  - Acknowledged
 //  - File Size: Medium
 //  - ~1% data lost in transport
-fn f1s4(fixture_f1s4: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s4;
-    let out_file: Utf8PathBuf = "remote/medium_f1s4.txt".into();
+fn f1s04(fixture_f1s04: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s04;
+    let out_file: Utf8PathBuf = "remote/medium_f1s04.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -205,7 +205,7 @@ fn f1s4(fixture_f1s4: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f1s5(
+fn fixture_f1s05(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -261,10 +261,10 @@ fn fixture_f1s5(
 //  - Acknowledged
 //  - File Size: Medium
 //  - ~1% data duplicated in transport
-fn f1s5(fixture_f1s5: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s5;
+fn f1s05(fixture_f1s05: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s05;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s5.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s05.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -287,7 +287,7 @@ fn f1s5(fixture_f1s5: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f1s6(
+fn fixture_f1s06(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -343,11 +343,11 @@ fn fixture_f1s6(
 //  - Acknowledged
 //  - File Size: Medium
 //  - ~1% data re-ordered in transport
-fn f1s6(fixture_f1s6: &'static EntityConstructorReturn) {
+fn f1s06(fixture_f1s06: &'static EntityConstructorReturn) {
     // let mut user = User::new(Some(_local_path))
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s6;
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s06;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s6.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s06.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -379,11 +379,11 @@ fn f1s6(fixture_f1s6: &'static EntityConstructorReturn) {
 //  - File Size: Zero
 //  - Have proxy put request send Entity 0 data,
 //  -   then have a proxy put request in THAT message send data back to entity 1
-fn f1s7(get_filestore: &UsersAndFilestore) {
+fn f1s07(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "/remote/medium_f1s7.txt".into();
-    let interim_file: Utf8PathBuf = "/local/medium_f1s7.txt".into();
+    let out_file: Utf8PathBuf = "/remote/medium_f1s07.txt".into();
+    let interim_file: Utf8PathBuf = "/local/medium_f1s07.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
     let path_interim = filestore.get_native_path(&interim_file);
 
@@ -465,10 +465,10 @@ fn f1s7(get_filestore: &UsersAndFilestore) {
 //  - Check User Cancel Functionality
 // Configuration:
 //  - Cancel initiated from Sender
-fn f1s8(get_filestore: &UsersAndFilestore) {
+fn f1s08(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s8.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s08.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user
@@ -513,10 +513,10 @@ fn f1s8(get_filestore: &UsersAndFilestore) {
 //  - Check User Cancel Functionality
 // Configuration:
 //  - Cancel initiated from Receiver
-fn f1s9(get_filestore: &UsersAndFilestore) {
+fn f1s09(get_filestore: &UsersAndFilestore) {
     let (local_user, remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s9.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s09.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user

--- a/cfdp-core/tests/series_f1.rs
+++ b/cfdp-core/tests/series_f1.rs
@@ -1,6 +1,4 @@
 use std::{
-    collections::HashMap,
-    net::UdpSocket,
     sync::{atomic::AtomicBool, Arc},
     thread,
     time::Duration,
@@ -14,19 +12,18 @@ use cfdp_core::{
         Condition, EntityID, MessageToUser, ProxyOperation, ProxyPutRequest, TransmissionMode,
         UserOperation,
     },
-    transport::{PDUTransport, UdpTransport},
 };
 
 use rstest::{fixture, rstest};
 
 mod common;
 use common::{
-    create_daemons, get_filestore, terminate, EntityConstructorReturn, LossyTransport,
-    TransportIssue, UsersAndFilestore,
+    get_filestore, new_entities, terminate, EntityConstructorReturn, TransportIssue,
+    UsersAndFilestore,
 };
 
 #[rstest]
-#[timeout(Duration::from_secs(2))]
+#[timeout(Duration::from_secs(200))]
 // Series F1
 // Sequence 1 Test
 // Test goal:
@@ -128,46 +125,13 @@ fn fixture_f1s04(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
-    let (_, _, filestore) = get_filestore;
-    let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
-    let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
-
-    let local_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind local UDP.");
-    let local_addr = local_udp.local_addr().expect("Cannot find local address.");
-
-    let entity_map = {
-        let mut temp = HashMap::new();
-        temp.insert(EntityID::from(0_u16), local_addr);
-        temp.insert(EntityID::from(1_u16), remote_addr);
-        temp
-    };
-
-    let local_transport =
-        LossyTransport::try_from((local_udp, entity_map.clone(), TransportIssue::Rate(13)))
-            .expect("Unable to make Lossy Transport.");
-    let remote_transport =
-        UdpTransport::try_from((remote_udp, entity_map)).expect("Unable to make UdpTransport.");
-
-    let remote_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(0_u16)],
-            Box::new(remote_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let local_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(1_u16)],
-            Box::new(local_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let (local_user, remote_user, local, remote) = create_daemons(
-        filestore.clone(),
-        local_transport_map,
-        remote_transport_map,
-        terminate.clone(),
+    new_entities(
+        &get_filestore.2,
+        terminate,
+        Some(TransportIssue::Rate(13)),
+        None,
         [None; 3],
-    );
-    (local_user, remote_user, filestore.clone(), local, remote)
+    )
 }
 
 #[rstest]
@@ -209,46 +173,13 @@ fn fixture_f1s05(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
-    let (_, _, filestore) = get_filestore;
-    let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
-    let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
-
-    let local_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind local UDP.");
-    let local_addr = local_udp.local_addr().expect("Cannot find local address.");
-
-    let entity_map = {
-        let mut temp = HashMap::new();
-        temp.insert(EntityID::from(0_u16), local_addr);
-        temp.insert(EntityID::from(1_u16), remote_addr);
-        temp
-    };
-
-    let local_transport =
-        LossyTransport::try_from((local_udp, entity_map.clone(), TransportIssue::Duplicate(13)))
-            .expect("Unable to make Lossy Transport.");
-    let remote_transport =
-        UdpTransport::try_from((remote_udp, entity_map)).expect("Unable to make UdpTransport.");
-
-    let remote_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(0_u16)],
-            Box::new(remote_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let local_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(1_u16)],
-            Box::new(local_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let (local_user, remote_user, local, remote) = create_daemons(
-        filestore.clone(),
-        local_transport_map,
-        remote_transport_map,
-        terminate.clone(),
+    new_entities(
+        &get_filestore.2,
+        terminate,
+        Some(TransportIssue::Duplicate(13)),
+        None,
         [None; 3],
-    );
-    (local_user, remote_user, filestore.clone(), local, remote)
+    )
 }
 
 #[rstest]
@@ -291,46 +222,13 @@ fn fixture_f1s06(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
-    let (_, _, filestore) = get_filestore;
-    let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
-    let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
-
-    let local_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind local UDP.");
-    let local_addr = local_udp.local_addr().expect("Cannot find local address.");
-
-    let entity_map = {
-        let mut temp = HashMap::new();
-        temp.insert(EntityID::from(0_u16), local_addr);
-        temp.insert(EntityID::from(1_u16), remote_addr);
-        temp
-    };
-
-    let local_transport =
-        LossyTransport::try_from((local_udp, entity_map.clone(), TransportIssue::Reorder(13)))
-            .expect("Unable to make Lossy Transport.");
-    let remote_transport =
-        UdpTransport::try_from((remote_udp, entity_map)).expect("Unable to make UdpTransport.");
-
-    let remote_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(0_u16)],
-            Box::new(remote_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let local_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(1_u16)],
-            Box::new(local_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let (local_user, remote_user, local, remote) = create_daemons(
-        filestore.clone(),
-        local_transport_map,
-        remote_transport_map,
-        terminate.clone(),
+    new_entities(
+        &get_filestore.2,
+        terminate,
+        Some(TransportIssue::Reorder(13)),
+        None,
         [None; 3],
-    );
-    (local_user, remote_user, filestore.clone(), local, remote)
+    )
 }
 
 #[rstest]

--- a/cfdp-core/tests/series_f2.rs
+++ b/cfdp-core/tests/series_f2.rs
@@ -23,7 +23,7 @@ use common::{
 
 #[fixture]
 #[once]
-fn fixture_f2s1(
+fn fixture_f2s01(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -83,11 +83,11 @@ fn fixture_f2s1(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of Metadata PDU
-fn f2s1(fixture_f2s1: &'static EntityConstructorReturn) {
+fn f2s01(fixture_f2s01: &'static EntityConstructorReturn) {
     // let mut user = User::new(Some(_local_path))
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s1;
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s01;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s1.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s01.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -110,7 +110,7 @@ fn f2s1(fixture_f2s1: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s2(
+fn fixture_f2s02(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -170,10 +170,10 @@ fn fixture_f2s2(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of EoF PDU
-fn f2s2(fixture_f2s2: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s2;
+fn f2s02(fixture_f2s02: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s02;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s2.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s02.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -196,7 +196,7 @@ fn f2s2(fixture_f2s2: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s3(
+fn fixture_f2s03(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -255,10 +255,10 @@ fn fixture_f2s3(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of Finished PDU
-fn f2s3(fixture_f2s3: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s3;
+fn f2s03(fixture_f2s03: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s03;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s3.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s03.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -281,7 +281,7 @@ fn f2s3(fixture_f2s3: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s4(
+fn fixture_f2s04(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -340,10 +340,10 @@ fn fixture_f2s4(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of ACK(EOF) PDU
-fn f2s4(fixture_f2s4: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s4;
+fn f2s04(fixture_f2s04: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s04;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s4.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s04.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -366,7 +366,7 @@ fn f2s4(fixture_f2s4: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s5(
+fn fixture_f2s05(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -425,10 +425,10 @@ fn fixture_f2s5(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of ACK(Fin) PDU
-fn f2s5(fixture_f2s5: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s5;
+fn f2s05(fixture_f2s05: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s05;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s5.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s05.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -451,7 +451,7 @@ fn f2s5(fixture_f2s5: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s6(
+fn fixture_f2s06(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -508,10 +508,10 @@ fn fixture_f2s6(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of Every non-EOF pdu in both directions
-fn f2s6(fixture_f2s6: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s6;
+fn f2s06(fixture_f2s06: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s06;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s6.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s06.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -534,7 +534,7 @@ fn f2s6(fixture_f2s6: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s7(
+fn fixture_f2s07(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -593,10 +593,10 @@ fn fixture_f2s7(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop all ACK and Finished PDUs
-fn f2s7(fixture_f2s7: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s7;
+fn f2s07(fixture_f2s07: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s07;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s7.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s07.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user
@@ -634,7 +634,7 @@ fn f2s7(fixture_f2s7: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s8(
+fn fixture_f2s08(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -697,10 +697,10 @@ fn fixture_f2s8(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop all NAK from receiver.
-fn f2s8(fixture_f2s8: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s8;
+fn f2s08(fixture_f2s08: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s08;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s8.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s08.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user
@@ -735,7 +735,7 @@ fn f2s8(fixture_f2s8: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s9(
+fn fixture_f2s09(
     get_filestore: &UsersAndFilestore,
     terminate: &Arc<AtomicBool>,
 ) -> EntityConstructorReturn {
@@ -794,10 +794,10 @@ fn fixture_f2s9(
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop all Finished from receiver.
-fn f2s9(fixture_f2s9: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s9;
+fn f2s09(fixture_f2s09: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s09;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s9.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s09.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user


### PR DESCRIPTION
While messing around with the async code I've noticed quite some code duplication in the f series tests.
I made one function new_entities to create entities/transports with different conifgs and I replaced all the code in the  fixture_fxzyz with a call to that function. 
From my point of view, the fixtue_fxsyz from series_f1 and f2 can be removed altogether and we can add the call to the new_entities directly in the test itself. Each of those fixtures is only used once so we do not really need them.
In addition, the #[once] annotation does not seem to work with async, so it's good to have less of them...