### PR TITLE
Removes the terminate signal from Daemon::new

### DIFF
--- a/cfdp-core/src/daemon.rs
+++ b/cfdp-core/src/daemon.rs
@@ -339,12 +339,12 @@ impl<T: FileStore + Send + Sync + 'static> Daemon<T> {
         filestore: Arc<T>,
         entity_configs: HashMap<VariableID, EntityConfig>,
         default_config: EntityConfig,
-        terminate: Arc<AtomicBool>,
         primitive_rx: Receiver<UserPrimitive>,
         indication_tx: Sender<Indication>,
     ) -> Self {
         let mut transport_tx_map: HashMap<EntityID, Sender<(VariableID, PDU)>> = HashMap::new();
         let (pdu_send, pdu_receive) = unbounded();
+        let terminate = Arc::new(AtomicBool::new(false));
         for (vec, mut transport) in transport_map.into_iter() {
             let (remote_send, remote_receive) = bounded(1);
 

--- a/cfdp-core/tests/series_f1.rs
+++ b/cfdp-core/tests/series_f1.rs
@@ -28,10 +28,10 @@ use common::{
 // Configuration:
 //  - Unacknowledged
 //  - File Size: Small (file fits in single pdu)
-fn f1s1(get_filestore: &UsersAndFilestore) {
+fn f1s01(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/small_f1s1.txt".into();
+    let out_file: Utf8PathBuf = "remote/small_f1s01.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -60,10 +60,10 @@ fn f1s1(get_filestore: &UsersAndFilestore) {
 // Configuration:
 //  - Unacknowledged
 //  - File Size: Medium
-fn f1s2(get_filestore: &UsersAndFilestore) {
+fn f1s02(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s2.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s02.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -92,10 +92,10 @@ fn f1s2(get_filestore: &UsersAndFilestore) {
 // Configuration:
 //  - Acknowledged
 //  - File Size: Medium
-fn f1s3(get_filestore: &UsersAndFilestore) {
+fn f1s03(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s3.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s03.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -118,7 +118,7 @@ fn f1s3(get_filestore: &UsersAndFilestore) {
 
 #[fixture]
 #[once]
-fn fixture_f1s4(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f1s04(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -170,9 +170,9 @@ fn fixture_f1s4(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - ~1% data lost in transport
-fn f1s4(fixture_f1s4: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s4;
-    let out_file: Utf8PathBuf = "remote/medium_f1s4.txt".into();
+fn f1s04(fixture_f1s04: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s04;
+    let out_file: Utf8PathBuf = "remote/medium_f1s04.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -195,7 +195,7 @@ fn f1s4(fixture_f1s4: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f1s5(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f1s05(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -247,10 +247,10 @@ fn fixture_f1s5(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - ~1% data duplicated in transport
-fn f1s5(fixture_f1s5: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s5;
+fn f1s05(fixture_f1s05: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s05;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s5.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s05.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -273,7 +273,7 @@ fn f1s5(fixture_f1s5: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f1s6(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f1s06(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -325,11 +325,11 @@ fn fixture_f1s6(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - ~1% data re-ordered in transport
-fn f1s6(fixture_f1s6: &'static EntityConstructorReturn) {
+fn f1s06(fixture_f1s06: &'static EntityConstructorReturn) {
     // let mut user = User::new(Some(_local_path))
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s6;
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f1s06;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s6.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s06.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -361,11 +361,11 @@ fn f1s6(fixture_f1s6: &'static EntityConstructorReturn) {
 //  - File Size: Zero
 //  - Have proxy put request send Entity 0 data,
 //  -   then have a proxy put request in THAT message send data back to entity 1
-fn f1s7(get_filestore: &UsersAndFilestore) {
+fn f1s07(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "/remote/medium_f1s7.txt".into();
-    let interim_file: Utf8PathBuf = "/local/medium_f1s7.txt".into();
+    let out_file: Utf8PathBuf = "/remote/medium_f1s07.txt".into();
+    let interim_file: Utf8PathBuf = "/local/medium_f1s07.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
     let path_interim = filestore.get_native_path(&interim_file);
 
@@ -447,10 +447,10 @@ fn f1s7(get_filestore: &UsersAndFilestore) {
 //  - Check User Cancel Functionality
 // Configuration:
 //  - Cancel initiated from Sender
-fn f1s8(get_filestore: &UsersAndFilestore) {
+fn f1s08(get_filestore: &UsersAndFilestore) {
     let (local_user, _remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s8.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s08.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user
@@ -495,10 +495,10 @@ fn f1s8(get_filestore: &UsersAndFilestore) {
 //  - Check User Cancel Functionality
 // Configuration:
 //  - Cancel initiated from Receiver
-fn f1s9(get_filestore: &UsersAndFilestore) {
+fn f1s09(get_filestore: &UsersAndFilestore) {
     let (local_user, remote_user, filestore) = get_filestore;
 
-    let out_file: Utf8PathBuf = "remote/medium_f1s9.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f1s09.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user

--- a/cfdp-core/tests/series_f1.rs
+++ b/cfdp-core/tests/series_f1.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashMap,
-    net::UdpSocket,
-    sync::{atomic::AtomicBool, Arc},
-    thread,
-    time::Duration,
-};
+use std::{collections::HashMap, net::UdpSocket, thread, time::Duration};
 
 use camino::Utf8PathBuf;
 use cfdp_core::{
@@ -21,8 +15,8 @@ use rstest::{fixture, rstest};
 
 mod common;
 use common::{
-    create_daemons, get_filestore, terminate, EntityConstructorReturn, LossyTransport,
-    TransportIssue, UsersAndFilestore,
+    create_daemons, get_filestore, EntityConstructorReturn, LossyTransport, TransportIssue,
+    UsersAndFilestore,
 };
 
 #[rstest]
@@ -124,10 +118,7 @@ fn f1s3(get_filestore: &UsersAndFilestore) {
 
 #[fixture]
 #[once]
-fn fixture_f1s4(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f1s4(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -164,7 +155,6 @@ fn fixture_f1s4(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -205,10 +195,7 @@ fn f1s4(fixture_f1s4: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f1s5(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f1s5(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -245,7 +232,6 @@ fn fixture_f1s5(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -287,10 +273,7 @@ fn f1s5(fixture_f1s5: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f1s6(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f1s6(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -327,7 +310,6 @@ fn fixture_f1s6(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)

--- a/cfdp-core/tests/series_f1.rs
+++ b/cfdp-core/tests/series_f1.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::UdpSocket, thread, time::Duration};
+use std::{thread, time::Duration};
 
 use camino::Utf8PathBuf;
 use cfdp_core::{
@@ -8,19 +8,17 @@ use cfdp_core::{
         Condition, EntityID, MessageToUser, ProxyOperation, ProxyPutRequest, TransmissionMode,
         UserOperation,
     },
-    transport::{PDUTransport, UdpTransport},
 };
 
 use rstest::{fixture, rstest};
 
 mod common;
 use common::{
-    create_daemons, get_filestore, EntityConstructorReturn, LossyTransport, TransportIssue,
-    UsersAndFilestore,
+    get_filestore, new_entities, EntityConstructorReturn, TransportIssue, UsersAndFilestore,
 };
 
 #[rstest]
-#[timeout(Duration::from_secs(2))]
+#[timeout(Duration::from_secs(200))]
 // Series F1
 // Sequence 1 Test
 // Test goal:
@@ -119,45 +117,12 @@ fn f1s03(get_filestore: &UsersAndFilestore) {
 #[fixture]
 #[once]
 fn fixture_f1s04(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
-    let (_, _, filestore) = get_filestore;
-    let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
-    let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
-
-    let local_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind local UDP.");
-    let local_addr = local_udp.local_addr().expect("Cannot find local address.");
-
-    let entity_map = {
-        let mut temp = HashMap::new();
-        temp.insert(EntityID::from(0_u16), local_addr);
-        temp.insert(EntityID::from(1_u16), remote_addr);
-        temp
-    };
-
-    let local_transport =
-        LossyTransport::try_from((local_udp, entity_map.clone(), TransportIssue::Rate(13)))
-            .expect("Unable to make Lossy Transport.");
-    let remote_transport =
-        UdpTransport::try_from((remote_udp, entity_map)).expect("Unable to make UdpTransport.");
-
-    let remote_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(0_u16)],
-            Box::new(remote_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let local_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(1_u16)],
-            Box::new(local_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let (local_user, remote_user, local, remote) = create_daemons(
-        filestore.clone(),
-        local_transport_map,
-        remote_transport_map,
+    new_entities(
+        &get_filestore.2,
+        Some(TransportIssue::Rate(13)),
+        None,
         [None; 3],
-    );
-    (local_user, remote_user, filestore.clone(), local, remote)
+    )
 }
 
 #[rstest]
@@ -196,45 +161,12 @@ fn f1s04(fixture_f1s04: &'static EntityConstructorReturn) {
 #[fixture]
 #[once]
 fn fixture_f1s05(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
-    let (_, _, filestore) = get_filestore;
-    let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
-    let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
-
-    let local_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind local UDP.");
-    let local_addr = local_udp.local_addr().expect("Cannot find local address.");
-
-    let entity_map = {
-        let mut temp = HashMap::new();
-        temp.insert(EntityID::from(0_u16), local_addr);
-        temp.insert(EntityID::from(1_u16), remote_addr);
-        temp
-    };
-
-    let local_transport =
-        LossyTransport::try_from((local_udp, entity_map.clone(), TransportIssue::Duplicate(13)))
-            .expect("Unable to make Lossy Transport.");
-    let remote_transport =
-        UdpTransport::try_from((remote_udp, entity_map)).expect("Unable to make UdpTransport.");
-
-    let remote_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(0_u16)],
-            Box::new(remote_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let local_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(1_u16)],
-            Box::new(local_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let (local_user, remote_user, local, remote) = create_daemons(
-        filestore.clone(),
-        local_transport_map,
-        remote_transport_map,
+    new_entities(
+        &get_filestore.2,
+        Some(TransportIssue::Duplicate(13)),
+        None,
         [None; 3],
-    );
-    (local_user, remote_user, filestore.clone(), local, remote)
+    )
 }
 
 #[rstest]
@@ -274,45 +206,12 @@ fn f1s05(fixture_f1s05: &'static EntityConstructorReturn) {
 #[fixture]
 #[once]
 fn fixture_f1s06(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
-    let (_, _, filestore) = get_filestore;
-    let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
-    let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
-
-    let local_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind local UDP.");
-    let local_addr = local_udp.local_addr().expect("Cannot find local address.");
-
-    let entity_map = {
-        let mut temp = HashMap::new();
-        temp.insert(EntityID::from(0_u16), local_addr);
-        temp.insert(EntityID::from(1_u16), remote_addr);
-        temp
-    };
-
-    let local_transport =
-        LossyTransport::try_from((local_udp, entity_map.clone(), TransportIssue::Reorder(13)))
-            .expect("Unable to make Lossy Transport.");
-    let remote_transport =
-        UdpTransport::try_from((remote_udp, entity_map)).expect("Unable to make UdpTransport.");
-
-    let remote_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(0_u16)],
-            Box::new(remote_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let local_transport_map: HashMap<Vec<EntityID>, Box<dyn PDUTransport + Send>> =
-        HashMap::from([(
-            vec![EntityID::from(1_u16)],
-            Box::new(local_transport) as Box<dyn PDUTransport + Send>,
-        )]);
-
-    let (local_user, remote_user, local, remote) = create_daemons(
-        filestore.clone(),
-        local_transport_map,
-        remote_transport_map,
+    new_entities(
+        &get_filestore.2,
+        Some(TransportIssue::Reorder(13)),
+        None,
         [None; 3],
-    );
-    (local_user, remote_user, filestore.clone(), local, remote)
+    )
 }
 
 #[rstest]

--- a/cfdp-core/tests/series_f2.rs
+++ b/cfdp-core/tests/series_f2.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashMap,
-    net::UdpSocket,
-    sync::{atomic::AtomicBool, Arc},
-    thread,
-    time::Duration,
-};
+use std::{collections::HashMap, net::UdpSocket, thread, time::Duration};
 
 use camino::Utf8PathBuf;
 use cfdp_core::{
@@ -17,16 +11,13 @@ use rstest::{fixture, rstest};
 
 mod common;
 use common::{
-    create_daemons, get_filestore, terminate, EntityConstructorReturn, LossyTransport,
-    TransportIssue, UsersAndFilestore,
+    create_daemons, get_filestore, EntityConstructorReturn, LossyTransport, TransportIssue,
+    UsersAndFilestore,
 };
 
 #[fixture]
 #[once]
-fn fixture_f2s1(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s1(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
 
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
@@ -67,7 +58,6 @@ fn fixture_f2s1(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -110,10 +100,7 @@ fn f2s1(fixture_f2s1: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s2(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s2(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
 
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
@@ -154,7 +141,6 @@ fn fixture_f2s2(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -196,10 +182,7 @@ fn f2s2(fixture_f2s2: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s3(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s3(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -239,7 +222,6 @@ fn fixture_f2s3(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -281,10 +263,7 @@ fn f2s3(fixture_f2s3: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s4(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s4(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -324,7 +303,6 @@ fn fixture_f2s4(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -366,10 +344,7 @@ fn f2s4(fixture_f2s4: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s5(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s5(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -409,7 +384,6 @@ fn fixture_f2s5(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -451,10 +425,7 @@ fn f2s5(fixture_f2s5: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s6(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s6(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -492,7 +463,6 @@ fn fixture_f2s6(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [None; 3],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -534,10 +504,7 @@ fn f2s6(fixture_f2s6: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s7(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s7(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -577,7 +544,6 @@ fn fixture_f2s7(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [Some(10), None, None],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -634,10 +600,7 @@ fn f2s7(fixture_f2s7: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s8(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s8(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -681,7 +644,6 @@ fn fixture_f2s8(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [Some(10), Some(1), Some(1)],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -735,10 +697,7 @@ fn f2s8(fixture_f2s8: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s9(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s9(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -778,7 +737,6 @@ fn fixture_f2s9(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [Some(1), Some(10), Some(1)],
     );
     (local_user, remote_user, filestore.clone(), local, remote)
@@ -833,10 +791,7 @@ fn f2s9(fixture_f2s9: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s10(
-    get_filestore: &UsersAndFilestore,
-    terminate: &Arc<AtomicBool>,
-) -> EntityConstructorReturn {
+fn fixture_f2s10(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -873,7 +828,6 @@ fn fixture_f2s10(
         filestore.clone(),
         local_transport_map,
         remote_transport_map,
-        terminate.clone(),
         [Some(1), Some(10), Some(10)],
     );
     (local_user, remote_user, filestore.clone(), local, remote)

--- a/cfdp-core/tests/series_f2.rs
+++ b/cfdp-core/tests/series_f2.rs
@@ -17,7 +17,7 @@ use common::{
 
 #[fixture]
 #[once]
-fn fixture_f2s1(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s01(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
 
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
@@ -73,11 +73,11 @@ fn fixture_f2s1(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of Metadata PDU
-fn f2s1(fixture_f2s1: &'static EntityConstructorReturn) {
+fn f2s01(fixture_f2s01: &'static EntityConstructorReturn) {
     // let mut user = User::new(Some(_local_path))
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s1;
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s01;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s1.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s01.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -100,7 +100,7 @@ fn f2s1(fixture_f2s1: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s2(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s02(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
 
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
@@ -156,10 +156,10 @@ fn fixture_f2s2(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of EoF PDU
-fn f2s2(fixture_f2s2: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s2;
+fn f2s02(fixture_f2s02: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s02;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s2.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s02.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -182,7 +182,7 @@ fn f2s2(fixture_f2s2: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s3(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s03(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -237,10 +237,10 @@ fn fixture_f2s3(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of Finished PDU
-fn f2s3(fixture_f2s3: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s3;
+fn f2s03(fixture_f2s03: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s03;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s3.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s03.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -263,7 +263,7 @@ fn f2s3(fixture_f2s3: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s4(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s04(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -318,10 +318,10 @@ fn fixture_f2s4(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of ACK(EOF) PDU
-fn f2s4(fixture_f2s4: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s4;
+fn f2s04(fixture_f2s04: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s04;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s4.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s04.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -344,7 +344,7 @@ fn f2s4(fixture_f2s4: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s5(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s05(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -399,10 +399,10 @@ fn fixture_f2s5(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of ACK(Fin) PDU
-fn f2s5(fixture_f2s5: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s5;
+fn f2s05(fixture_f2s05: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s05;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s5.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s05.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -425,7 +425,7 @@ fn f2s5(fixture_f2s5: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s6(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s06(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -478,10 +478,10 @@ fn fixture_f2s6(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop first instance of Every non-EOF pdu in both directions
-fn f2s6(fixture_f2s6: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s6;
+fn f2s06(fixture_f2s06: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s06;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s6.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s06.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     local_user
@@ -504,7 +504,7 @@ fn f2s6(fixture_f2s6: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s7(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s07(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -559,10 +559,10 @@ fn fixture_f2s7(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop all ACK and Finished PDUs
-fn f2s7(fixture_f2s7: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s7;
+fn f2s07(fixture_f2s07: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s07;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s7.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s07.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user
@@ -600,7 +600,7 @@ fn f2s7(fixture_f2s7: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s8(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s08(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -659,10 +659,10 @@ fn fixture_f2s8(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop all NAK from receiver.
-fn f2s8(fixture_f2s8: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s8;
+fn f2s08(fixture_f2s08: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s08;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s8.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s08.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user
@@ -697,7 +697,7 @@ fn f2s8(fixture_f2s8: &'static EntityConstructorReturn) {
 
 #[fixture]
 #[once]
-fn fixture_f2s9(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
+fn fixture_f2s09(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
     let (_, _, filestore) = get_filestore;
     let remote_udp = UdpSocket::bind("127.0.0.1:0").expect("Unable to bind remote UDP.");
     let remote_addr = remote_udp.local_addr().expect("Cannot find local address.");
@@ -752,10 +752,10 @@ fn fixture_f2s9(get_filestore: &UsersAndFilestore) -> EntityConstructorReturn {
 //  - Acknowledged
 //  - File Size: Medium
 //  - Drop all Finished from receiver.
-fn f2s9(fixture_f2s9: &'static EntityConstructorReturn) {
-    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s9;
+fn f2s09(fixture_f2s09: &'static EntityConstructorReturn) {
+    let (local_user, _remote_user, filestore, _local, _remote) = fixture_f2s09;
 
-    let out_file: Utf8PathBuf = "remote/medium_f2s9.txt".into();
+    let out_file: Utf8PathBuf = "remote/medium_f2s09.txt".into();
     let path_to_out = filestore.get_native_path(&out_file);
 
     let id = local_user


### PR DESCRIPTION
The terminate signal is created now inside Daemon::new to be used in relation with the transport. Can probably be remove later (I suggest after async) also from there and just use the channel closure as termination indication.

The terminate signal was shared between the series_fX tests and was causing spurious test failures.

closes #38