### PR TITLE
update re-exports

### DIFF
--- a/cfdp-core/Cargo.toml
+++ b/cfdp-core/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 [dependencies]
 byteorder = "~1.4"
 camino = {version = "~1.1", features=["serde1"]}
-crossbeam-channel = "~0.5"
 itertools = "~0.10"
 log = '~0.4'
 num-derive = "0.3"

--- a/cfdp-core/src/lib.rs
+++ b/cfdp-core/src/lib.rs
@@ -6,7 +6,10 @@ pub(crate) mod timer;
 pub mod transaction;
 pub mod transport;
 // Re-exported for convenience
-pub use crossbeam_channel::{bounded, unbounded, Receiver, Sender, TryRecvError};
+pub use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    oneshot,
+};
 
 // this import is necessary for the template macro in rstest_reuse as of v0.5.0
 #[cfg(test)]


### PR DESCRIPTION
updates the re-exports to point to tokio not crossbeam channels.
removes the crossbeam-channel dependency entirely.