### PR TITLE
Minor code cleanups

### DIFF
--- a/cfdp-core/src/transaction/recv.rs
+++ b/cfdp-core/src/transaction/recv.rs
@@ -884,16 +884,9 @@ impl<T: FileStore> RecvTransaction<T> {
                                             _ => None,
                                         });
                                     // push each request up to the Daemon
-                                    let source_filename: Utf8PathBuf =
-                                        std::str::from_utf8(metadata.source_filename.as_slice())
-                                            .map_err(FileStoreError::UTF8)?
-                                            .into();
-
-                                    let destination_filename: Utf8PathBuf = std::str::from_utf8(
-                                        metadata.destination_filename.as_slice(),
-                                    )
-                                    .map_err(FileStoreError::UTF8)?
-                                    .into();
+                                    let source_filename: Utf8PathBuf = metadata.source_filename;
+                                    let destination_filename: Utf8PathBuf =
+                                        metadata.destination_filename;
 
                                     self.send_indication(Indication::MetadataRecv(
                                         MetadataRecvIndication {
@@ -1026,16 +1019,9 @@ impl<T: FileStore> RecvTransaction<T> {
                                             _ => None,
                                         });
 
-                                    let source_filename: Utf8PathBuf =
-                                        std::str::from_utf8(metadata.source_filename.as_slice())
-                                            .map_err(FileStoreError::UTF8)?
-                                            .into();
-
-                                    let destination_filename: Utf8PathBuf = std::str::from_utf8(
-                                        metadata.destination_filename.as_slice(),
-                                    )
-                                    .map_err(FileStoreError::UTF8)?
-                                    .into();
+                                    let source_filename: Utf8PathBuf = metadata.source_filename;
+                                    let destination_filename: Utf8PathBuf =
+                                        metadata.destination_filename;
 
                                     self.send_indication(Indication::MetadataRecv(
                                         MetadataRecvIndication {
@@ -1965,8 +1951,8 @@ mod test {
             closure_requested: false,
             checksum_type: ChecksumType::Modular,
             file_size: 600,
-            source_filename: "Test_file.txt".as_bytes().to_vec(),
-            destination_filename: "Test_file.txt".as_bytes().to_vec(),
+            source_filename: "Test_file.txt".into(),
+            destination_filename: "Test_file.txt".into(),
             options: vec![
                 MetadataTLV::MessageToUser(expected_msg.clone()),
                 MetadataTLV::FileStoreRequest(fs_req),

--- a/cfdp-core/src/transaction/send.rs
+++ b/cfdp-core/src/transaction/send.rs
@@ -892,13 +892,8 @@ impl<T: FileStore> SendTransaction<T> {
             closure_requested: self.metadata.closure_requested,
             checksum_type: self.metadata.checksum_type,
             file_size: self.metadata.file_size,
-            source_filename: self.metadata.source_filename.as_str().as_bytes().to_vec(),
-            destination_filename: self
-                .metadata
-                .destination_filename
-                .as_str()
-                .as_bytes()
-                .to_vec(),
+            source_filename: self.metadata.source_filename.clone(),
+            destination_filename: self.metadata.destination_filename.clone(),
             options: self
                 .metadata
                 .filestore_requests
@@ -1138,8 +1133,8 @@ mod test {
                     closure_requested: false,
                     file_size: 10,
                     checksum_type: ChecksumType::Modular,
-                    source_filename: path.as_str().as_bytes().to_vec(),
-                    destination_filename: path.as_str().as_bytes().to_vec(),
+                    source_filename: path.clone(),
+                    destination_filename: path.clone(),
                     options: vec![],
                 }));
                 let payload_len = payload.encoded_len(transaction.config.file_size_flag);
@@ -1599,8 +1594,8 @@ mod test {
                 closure_requested: false,
                 checksum_type: ChecksumType::Modular,
                 file_size: 1022_u64,
-                source_filename: "test_filename".as_bytes().to_vec(),
-                destination_filename: "test_filename".as_bytes().to_vec(),
+                source_filename: "test_filename".into(),
+                destination_filename: "test_filename".into(),
                 options: vec![],
             }),
             Operations::Prompt(PromptPDU{


### PR DESCRIPTION
Broke up the larger logic blocks in the deamon's `select` statements to be their own functions.
Simplified the logic in transaction's `selects` to check for `Some(command)` or `Ok(permit)`s and condensed the failure mode to it's own select block.

Found some PDUs where `Vec<u8>` could be replaced with other more informative structures. This allowed for small cleanups in the recv and send transactions' handling of the metadata PDU.